### PR TITLE
Prefix deb version with 0.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -19,6 +19,6 @@ go build -v -o ${PROJECT_NAME}
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec fpm \
   -s dir -t deb \
-  -n ${PROJECT_NAME} -v ${BUILD_NUMBER} \
+  -n ${PROJECT_NAME} -v 0.${BUILD_NUMBER} \
   --prefix /usr/bin \
   ${PROJECT_NAME}


### PR DESCRIPTION
Otherwise we're going to end up with some very large integers. Prefixing
with `0.` will allow us to switch to a different scheme, or stabilize, in
the future.

We could also append `${GIT_COMMIT}` to this, should we wish to track that.
