### PR TITLE
Fix mux tests.

### DIFF
--- a/triemux/mux_test.go
+++ b/triemux/mux_test.go
@@ -187,7 +187,7 @@ func testLookup(t *testing.T, ex LookupExample) {
 }
 
 func loadStrings(filename string) []string {
-	content, err := ioutil.ReadFile("testdata/routes")
+	content, err := ioutil.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
They were always loading the testdata/routes file, and not the requested files.
