### PR TITLE
Set the Host header to match the backend hostname.

### DIFF
--- a/router.go
+++ b/router.go
@@ -138,5 +138,13 @@ func newBackendReverseProxy(backendUrl *url.URL) (proxy *httputil.ReverseProxy) 
 	// per upstream.
 	proxy.Transport = &http.Transport{MaxIdleConnsPerHost: 20}
 
+	defaultDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		defaultDirector(req)
+
+		// Set the Host header to match the backend hostname instead of the one from the incoming request.
+		req.Host = backendUrl.Host
+	}
+
 	return proxy
 }

--- a/spec/proxy_function_spec.rb
+++ b/spec/proxy_function_spec.rb
@@ -24,7 +24,6 @@ describe "functioning as a reverse proxy" do
     end
 
     it "should set the Host header to the backend hostname" do
-      pending "Host header munging hasn't been completed yet"
       response = HTTPClient.get(router_url("/foo"), :header => {"Host" => "www.example.com"})
       data = JSON.parse(response.body)
 


### PR DESCRIPTION
Default behaviour is to preserve the Host header from the incoming request.  In our use case, this won't work.
