### PR TITLE
Distinguish when router fails to start for tests

### DIFF
--- a/spec/support/router.rb
+++ b/spec/support/router.rb
@@ -41,7 +41,9 @@ module RouterHelpers
       begin
         s = TCPSocket.new("localhost", port)
       rescue Errno::ECONNREFUSED
-        if retries < 20
+        if !Process.waitpid(@router_pid, Process::WNOHANG).nil?
+          raise "The router process is no longer running"
+        elsif retries < 20
           retries += 1
           sleep 0.1
           retry


### PR DESCRIPTION
There's no point waiting for the process has exited early. Display a nicer
message rather than just connection refused. Might be useful to capture
STDERR for this purpose?
