### PR TITLE
Reorder logging and binding in main()

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,9 +23,10 @@ func main() {
 	rout := NewRouter(*mongoUrl, *mongoDbName)
 	rout.ReloadRoutes()
 
+	go http.ListenAndServe(*pubAddr, rout)
 	log.Println("router: listening for requests on " + *pubAddr)
-	log.Println("router: listening for refresh on " + *apiAddr)
 
+	// This applies to DefaultServeMux, below.
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			http.NotFound(w, r)
@@ -34,9 +35,8 @@ func main() {
 
 		rout.ReloadRoutes()
 	})
-
-	go http.ListenAndServe(*pubAddr, rout)
 	go http.ListenAndServe(*apiAddr, nil)
+	log.Println("router: listening for refresh on " + *apiAddr)
 
 	<-quit
 }


### PR DESCRIPTION
So that this flows a bit more logically. We shouldn't log about listening
on ports until we've started the relevant goroutines. Threads aside.

Also moved and commented the handler for the API server. Because someone new
to Go, like me, can find it hard to see how this method magically binds to
the `http.ListenAndServe` further down.
