### PR TITLE
[Delivers #58693908] Bail if unable to bind TCP ports

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,12 @@ func main() {
 	rout := NewRouter(*mongoUrl, *mongoDbName)
 	rout.ReloadRoutes()
 
-	go http.ListenAndServe(*pubAddr, rout)
+	go func() {
+		err := http.ListenAndServe(*pubAddr, rout)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 	log.Println("router: listening for requests on " + *pubAddr)
 
 	// This applies to DefaultServeMux, below.
@@ -35,7 +40,12 @@ func main() {
 
 		rout.ReloadRoutes()
 	})
-	go http.ListenAndServe(*apiAddr, nil)
+	go func() {
+		err := http.ListenAndServe(*apiAddr, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 	log.Println("router: listening for refresh on " + *apiAddr)
 
 	<-quit


### PR DESCRIPTION
We should bail early and with an error if we're unable to bind either of the
TCP ports required. This will prevent silent failures if two instances of
the router are started on the same machine, where previously the second
would just sit there never receiving traffic. Should also reduce false
positive errors from CI tests for similar situations.
