### PR TITLE
Rename quit channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,12 +7,12 @@ import (
 	"runtime"
 )
 
+var dontQuit = make(chan int)
+
 var pubAddr = flag.String("pubAddr", ":8080", "Address on which to serve public requests")
 var apiAddr = flag.String("apiAddr", ":8081", "Address on which to receive reload requests")
 var mongoUrl = flag.String("mongoUrl", "localhost", "Address of mongo cluster (e.g. 'mongo1,mongo2,mongo3')")
 var mongoDbName = flag.String("mongoDbName", "router", "Name of mongo database to use")
-
-var quit = make(chan int)
 
 func catchListenAndServe(addr string, handler http.Handler) {
 	err := http.ListenAndServe(addr, handler)
@@ -45,5 +45,5 @@ func main() {
 	go catchListenAndServe(*apiAddr, nil)
 	log.Println("router: listening for refresh on " + *apiAddr)
 
-	<-quit
+	<-dontQuit
 }


### PR DESCRIPTION
To make it more obvious that the name has no functional effect. This empty
channel is being read from, and passed nowhere, just as a blocking operation
to prevent `main()` from exiting and shutting down the goroutines.
