### PR TITLE
Disable FPM packaging for the moment

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,9 +11,3 @@ go build -v -o ${PROJECT_NAME}
 
 go test ./triemux
 USE_COMPILED_ROUTER=1 bundle exec rspec
-
-bundle exec fpm \
-  -s dir -t deb \
-  -n ${PROJECT_NAME} -v 0.${BUILD_NUMBER} \
-  --prefix /usr/bin \
-  ${PROJECT_NAME}


### PR DESCRIPTION
Until we can sign and stuff these packages into an APT repo, it will be
problematic/impossible to install these in a safe way - without blanket sudo
access, for example. So disable package creation for the moment. We'll just
store the raw binary.
## 

I'll modify the Jenkins job when merged.
