### PR TITLE
Reload API integration tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	// This applies to DefaultServeMux, below.
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" || r.RequestURI != "/" {
+		if r.Method != "POST" || r.RequestURI != "/reload" {
 			http.NotFound(w, r)
 			return
 		}

--- a/spec/reload_api_spec.rb
+++ b/spec/reload_api_spec.rb
@@ -9,7 +9,7 @@ describe "reload API endpoint" do
 
   describe "request handling" do
     it "should return 200 for POST /" do
-      response = HTTPClient.post(api_url("/"))
+      response = HTTPClient.post(api_url("/reload"))
       expect(response.status).to eq(200)
     end
 

--- a/spec/support/router.rb
+++ b/spec/support/router.rb
@@ -7,7 +7,7 @@ module RouterHelpers
   end
 
   def reload_routes
-    HTTPClient.post(api_url("/"))
+    HTTPClient.post(api_url("/reload"))
   end
 
   def router_url(path)


### PR DESCRIPTION
Tests the logic within `main()`:`http.HandleFunc()`.

Don't accept reload requests to /.*

We should be specific about what we support. Perhaps this should be modified
to `/reload` at some point?
