### PR TITLE
Set Allow header for 405 responses

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,8 @@ func newApiServeMux(rout *Router) (mux *http.ServeMux) {
 
 	mux.HandleFunc("/reload", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
-			http.Error(w, "405 method not allowed", http.StatusMethodNotAllowed)
+			w.Header().Set("Allow", "POST")
+			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 
@@ -80,7 +81,8 @@ func newApiServeMux(rout *Router) (mux *http.ServeMux) {
 	})
 	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
-			http.Error(w, "405 method not allowed", http.StatusMethodNotAllowed)
+			w.Header().Set("Allow", "GET")
+			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 

--- a/spec/reload_api_spec.rb
+++ b/spec/reload_api_spec.rb
@@ -22,6 +22,8 @@ describe "reload API endpoint" do
     it "should return 405 for GET /reload" do
       response = HTTPClient.get(api_url("/reload"))
       expect(response.status).to eq(405)
+      expect(response.reason).to eq("Method Not Allowed")
+      expect(response.headers["Allow"]).to eq("POST")
     end
   end
 
@@ -35,6 +37,8 @@ describe "reload API endpoint" do
     it "should respond with 405 for other verbs" do
       response = HTTPClient.post(api_url("/healthcheck"))
       expect(response.status).to eq(405)
+      expect(response.reason).to eq("Method Not Allowed")
+      expect(response.headers["Allow"]).to eq("GET")
     end
   end
 


### PR DESCRIPTION
The HTTP spec says this is a MUST:

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7

Also swap `http.Error()` for the shorter-hand `w.WriteHeader()`, with a spec
assertion that we're returning the correct status reason.
