### PR TITLE
Tarpit test backend.

### DIFF
--- a/spec/test_backends/tarpit_backend.go
+++ b/spec/test_backends/tarpit_backend.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+var port = flag.Int("port", 3160, "The port to listen on")
+var responseDelay = flag.Duration("response-delay", 2 * time.Second, "Delay in seconds before start of response")
+
+func main() {
+	flag.Parse()
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(*responseDelay)
+		fmt.Fprintln(w, "Tarpit")
+	})
+
+	addr := fmt.Sprintf(":%d", *port)
+
+	err := http.ListenAndServe(addr, nil)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}


### PR DESCRIPTION
Sleeps for a configurable duration before returning a response (I was tempted to name it Whitehall).
