### PR TITLE
Tweak build_gopath.sh to not use readlink.

### DIFF
--- a/build_gopath.sh
+++ b/build_gopath.sh
@@ -2,8 +2,9 @@
 
 set -eu
 
-REPO_ROOT=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
+REPO_ROOT=$(dirname ${BASH_SOURCE[0]})
 cd $REPO_ROOT
+REPO_ROOT=$(pwd) # Resolve relative paths
 
 export GOPATH="$REPO_ROOT/gopath.tmp"
 export GOBIN="$GOPATH/bin"


### PR DESCRIPTION
This will enable it to work on systems taht don't support `readlink -f` (i.e. OS X)

Supersedes #44
