### PR TITLE
Use a non relative latency threshold for perf tests

### DIFF
--- a/spec/performance_spec.rb
+++ b/spec/performance_spec.rb
@@ -34,6 +34,9 @@ describe "performance" do
         :direct => results_direct["latencies"],
         :router => results_router["latencies"],
       }
+      puts "\ntwo healthy backends latencies"
+      pp res
+
       expect(res[:router]["max"]).to  be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["max"])
       expect(res[:router]["mean"]).to be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["mean"])
       expect(res[:router]["95th"]).to be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["95th"])
@@ -89,6 +92,9 @@ describe "performance" do
         :direct => results_direct["latencies"],
         :router => results_router["latencies"],
       }
+      puts "\none slow backend latencies"
+      pp res
+
       expect(res[:router]["max"]).to  be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["max"])
       expect(res[:router]["mean"]).to be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["mean"])
       expect(res[:router]["95th"]).to be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["95th"])
@@ -143,6 +149,9 @@ describe "performance" do
         :direct => results_direct["latencies"],
         :router => results_router["latencies"],
       }
+      puts "\none downed backend latencies"
+      pp res
+
       expect(res[:router]["max"]).to  be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["max"])
       expect(res[:router]["mean"]).to be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["mean"])
       expect(res[:router]["95th"]).to be_within(ROUTER_LATENCY_THRESHOLD).of(res[:direct]["95th"])


### PR DESCRIPTION
The problem is that our test backends are ridiculously fast, and therefore, 200% of approximately zero is still approximately zero.

This changes the test to assert that the router doesn't add more than 20ms latency to the requests.
