### PR TITLE
[Fixes #59040160] Throughput and concurrency tests

### DIFF
--- a/spec/performance_spec.rb
+++ b/spec/performance_spec.rb
@@ -93,5 +93,24 @@ describe "performance" do
 
       it_behaves_like "a performant router"
     end
+
+    describe "high request throughput", :ulimits => true do
+      it_behaves_like "a performant router", :rate => 3000
+    end
+  end
+
+  context "many concurrent (slow) connections", :ulimits => true do
+    start_backend_around_all :port => 3160, :type => :tarpit, "response-delay" => "1s"
+    start_backend_around_all :port => 3161, :type => :tarpit, "response-delay" => "1s"
+
+    before :each do
+      add_backend("backend-1", "http://localhost:3160/")
+      add_backend("backend-2", "http://localhost:3161/")
+      add_backend_route("/one", "backend-1")
+      add_backend_route("/two", "backend-1")
+      reload_routes
+    end
+
+    it_behaves_like "a performant router", :rate => 1000
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 
+  # Requires `ulimit -n 4096` or higher.
+  config.filter_run_excluding :ulimits => true
+
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.


### PR DESCRIPTION
Tests for throughput (requests per second) and concurrency (requests in
flight at a single point in time). These appear to be mostly limited by the
file descriptor ulimit of the process/shell that they are run from.

Because we're launching the following from rspec all in parallel:
- 2x Vegeta attack.
- 2x Vegeta report.
- 2x Simple backend.
- Router.

The combination of the above, not necessarily the router, is also pretty
harsh on system resources such as CPU. So it would be rude to run these from
CI. As such I'm marking them as optional. You can opt into running as
follows:

```
ulimit -n 4096
rspec --tag ulimits
```
