### PR TITLE
[#60401480] 24hr cache headers on redirects

### DIFF
--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -32,8 +32,6 @@ describe "Redirection" do
     end
 
     it "should contain cache headers of 24hrs" do
-      pending
-
       response = router_request("/foo")
       expect(response.headers['Cache-Control']).to eq("max-age=86400, public")
       expires = Time.parse(response.headers['Expires'])


### PR DESCRIPTION
To match existing behaviour of Nginx. Making this configurable has been pushed out to a separate story.
## 

Is there a cleaner way to implement the last commit?
