### PR TITLE
If a bad HTTP Content-Length header is provided; return a 500 response

### DIFF
--- a/spec/proxy_function_spec.rb
+++ b/spec/proxy_function_spec.rb
@@ -264,34 +264,31 @@ describe "functioning as a reverse proxy" do
   end
 
   describe "handling invalid Content-Length request headers" do
-
-    it "should log and return a 400 error if Content-Length is set with no request body" do
-      headers, body = raw_http_request(router_url("/foo"), "Host" => "www.example.com", "Content-Length" => 12)
-
-      expect(headers.first).to eq("HTTP/1.1 400 Bad Request")
+    it "returns a 500 error if Content-Length is set with no request body" do
+      headers, _ = raw_http_request(router_url("/foo"), "Host" => "www.example.com", "Content-Length" => 12)
+      expect(headers.first).to eq("HTTP/1.1 500 Internal Server Error")
 
       log_details = last_router_error_log_entry
       expect(log_details["@fields"]).to eq({
-        "error" => "http: Request.ContentLength=12 with Body length 0",
+        "error" => "unexpected EOF",
         "request" => "GET /foo HTTP/1.1",
         "request_method" => "GET",
-        "status" => 400,
+        "status" => 500,
         "upstream_addr" => "localhost:3163",
         "varnish_id" => "",
       })
     end
 
-    it "should log and return a 400 error if Content-Length is bigger than the request body size" do
-      headers, body = raw_http_request(router_url("/foo"), {"Host" => "www.example.com", "Content-Length" => 20}, "Short body")
-
-      expect(headers.first).to eq("HTTP/1.1 400 Bad Request")
+    it "returns a 500 error if Content-Length is bigger than the request body size" do
+      headers, _ = raw_http_request(router_url("/foo"), {"Host" => "www.example.com", "Content-Length" => 20}, "Short body")
+      expect(headers.first).to eq("HTTP/1.1 500 Internal Server Error")
 
       log_details = last_router_error_log_entry
       expect(log_details["@fields"]).to eq({
-        "error" => "http: Request.ContentLength=20 with Body length 10",
+        "error" => "unexpected EOF",
         "request" => "GET /foo HTTP/1.1",
         "request_method" => "GET",
-        "status" => 400,
+        "status" => 500,
         "upstream_addr" => "localhost:3163",
         "varnish_id" => "",
       })


### PR DESCRIPTION
This was a regression found when compiling and testing the router under go 1.2 compared to 1.1.2 (currently built against version). Since go 1.2 the behaviour for how bad Content-Length headers are handled has changed from providing a (private) error value that we could match against through to directly returning an io.ErrUnexpectedEOF error.

The issue that we raised with the Go project can be found here: https://code.google.com/p/go/issues/detail?id=8003

In a discussion between @alext, @dcarley and myself we agreed (and checked) that this behaviour wouldn't make it harder to track logs through our environments.

Question for the reviewer of this PR: I've kept the code that matched against `http: Request.ContentLength=\d+ with Body length \d+` in place but there's no longer a test for it as we can't hit it using the `RountTripper`. Should this also be removed?
