### PR TITLE
Use empty struct for daemon signalling channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 )
 
-var dontQuit = make(chan int)
 var (
 	pubAddr               = getenvDefault("ROUTER_PUBADDR", ":8080")
 	apiAddr               = getenvDefault("ROUTER_APIADDR", ":8081")
@@ -95,5 +94,6 @@ func main() {
 	go catchListenAndServe(apiAddr, api)
 	logInfo("router: listening for refresh on " + apiAddr)
 
+	dontQuit := make(chan struct{})
 	<-dontQuit
 }


### PR DESCRIPTION
Channels that are being used purely for signalling should use an
empty struct rather than boolean or int types.

Using an empty struct declares that we're not interested in the value
sent or received; only in its closed property.

See http://talks.golang.org/2012/10things.slide#11

It also does not need to be global.
