### PR TITLE
Add test for redirect target with a url fragment

### DIFF
--- a/integration_tests/redirect_test.go
+++ b/integration_tests/redirect_test.go
@@ -14,6 +14,7 @@ var _ = Describe("Redirection", func() {
 			addRedirectRoute("/foo", "/bar")
 			addRedirectRoute("/foo-temp", "/bar", "exact", "temporary")
 			addRedirectRoute("/query-temp", "/bar?query=true", "exact")
+			addRedirectRoute("/fragment", "/bar#section", "exact")
 			reloadRoutes()
 		})
 
@@ -40,6 +41,11 @@ var _ = Describe("Redirection", func() {
 		It("should preserve the query string for the target", func() {
 			resp := routerRequest("/query-temp")
 			Expect(resp.Header.Get("Location")).To(Equal("/bar?query=true"))
+		})
+
+		It("should preserve the fragment for the target", func() {
+			resp := routerRequest("/fragment")
+			Expect(resp.Header.Get("Location")).To(Equal("/bar#section"))
 		})
 
 		It("should contain cache headers of 24hrs", func() {


### PR DESCRIPTION
We want to start using redirects to anchor links within pages.  Adding
this here so that we can be sure that they'll work correctly before we
allow this in router-api
