### PR TITLE
Support for zero downtime restarts

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,4 +1,5 @@
 gom 'labix.org/v2/mgo', :commit => '245'
+gom 'github.com/alext/tablecloth', :commit => 'b373a9a'
 
 gom 'github.com/onsi/ginkgo', :tag => 'v1.1.0'
 gom 'github.com/onsi/gomega', :tag => 'v1.0'


### PR DESCRIPTION
This uses [tablecloth](http://godoc.org/github.com/alext/tablecloth) to add support for reloading the application
without dropping any requests.  The restart will additionally pick up a
new version of the binary if it has changed (ie when deploying)

This has involved switching to use a `sync.WaitGroup` to block the main
process once the servers have started.  Tablecloth requires that the
main process exits once all the ListenAndServe calls return.
