### PR TITLE
Tidy up handling of backend HTTP errors.

### DIFF
--- a/handlers/backend_handler.go
+++ b/handlers/backend_handler.go
@@ -2,16 +2,16 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/alphagov/router/logger"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"regexp"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/alphagov/router/logger"
 )
 
 func NewBackendHandler(backendUrl *url.URL, connectTimeout, headerTimeout time.Duration, logger logger.Logger) http.Handler {
@@ -67,8 +67,6 @@ func newBackendTransport(connectTimeout, headerTimeout time.Duration, logger log
 	return
 }
 
-var invalidContentLengthRegexp = regexp.MustCompile(`http: Request.ContentLength=\d+ with Body length \d+`)
-
 func (bt *backendTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	resp, err = bt.wrapped.RoundTrip(req)
 	if err == nil {
@@ -91,9 +89,6 @@ func (bt *backendTransport) RoundTrip(req *http.Request) (resp *http.Response, e
 		if err.Error() == "net/http: timeout awaiting response headers" {
 			logDetails["status"] = 504
 			return newErrorResponse(504), nil
-		} else if invalidContentLengthRegexp.MatchString(err.Error()) {
-			logDetails["status"] = 400
-			return newErrorResponse(400), nil
 		}
 
 		// 500 for all other errors


### PR DESCRIPTION
These were relying on matching specific error strings set by the `net/http` package.  This is a brittle approach, and there are better approaches, as the errors in question implement the `net.Error` interface.

This PR also removes specific handling for invalid content-length errors.  This hasn't worked since we upgraded to Go 1.2.

See individual commit messages for more details.