### PR TITLE
Add /memory-stats endpoint to the API.

### DIFF
--- a/integration_tests/reload_api_test.go
+++ b/integration_tests/reload_api_test.go
@@ -102,4 +102,22 @@ var _ = Describe("reload API endpoint", func() {
 			Expect(resp.Header.Get("Allow")).To(Equal("GET"))
 		})
 	})
+
+	Describe("memory stats", func() {
+		It("should return memory statistics", func() {
+			addRedirectRoute("/foo", "/bar", "prefix")
+			addRedirectRoute("/baz", "/qux", "prefix")
+			addRedirectRoute("/foo", "/bar/baz")
+			reloadRoutes()
+
+			resp := doRequest(newRequest("GET", routerAPIURL("/memory-stats")))
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var data map[string]interface{}
+			readJSONBody(resp, &data)
+
+			Expect(data).To(HaveKey("Alloc"))
+			Expect(data).To(HaveKey("HeapInuse"))
+		})
+	})
 })

--- a/router_api.go
+++ b/router_api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"runtime"
 )
 
 func newApiHandler(rout *Router) http.Handler {
@@ -37,6 +38,24 @@ func newApiHandler(rout *Router) http.Handler {
 		stats["routes"] = rout.RouteStats()
 
 		json_data, err := json.MarshalIndent(stats, "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		w.Write(json_data)
+		w.Write([]byte("\n"))
+	})
+	mux.HandleFunc("/memory-stats", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.Header().Set("Allow", "GET")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		memStats := &runtime.MemStats{}
+		runtime.ReadMemStats(memStats)
+
+		json_data, err := json.MarshalIndent(memStats, "", "  ")
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return


### PR DESCRIPTION
To help with debugging memory usage.

This could be useful, but It's worth noting that the `ReadMemoryStats()` call has to stop the world[1] in order to gather the stats, which could have a performance impact if it's hit rapidly.

[1] http://golang.org/src/runtime/mem.go?s=2417:2447#L63