### PR TITLE
Add plain text response to goneHandler.

### DIFF
--- a/integration_tests/gone_test.go
+++ b/integration_tests/gone_test.go
@@ -16,16 +16,20 @@ var _ = Describe("Gone routes", func() {
 	It("should support an exact gone route", func() {
 		resp := routerRequest("/foo")
 		Expect(resp.StatusCode).To(Equal(410))
+		Expect(readBody(resp)).To(Equal("410 gone\n"))
 
 		resp = routerRequest("/foo/bar")
 		Expect(resp.StatusCode).To(Equal(404))
+		Expect(readBody(resp)).To(Equal("404 page not found\n"))
 	})
 
 	It("should support a prefix gone route", func() {
 		resp := routerRequest("/bar")
 		Expect(resp.StatusCode).To(Equal(410))
+		Expect(readBody(resp)).To(Equal("410 gone\n"))
 
 		resp = routerRequest("/bar/baz")
 		Expect(resp.StatusCode).To(Equal(410))
+		Expect(readBody(resp)).To(Equal("410 gone\n"))
 	})
 })

--- a/router.go
+++ b/router.go
@@ -156,7 +156,7 @@ func loadRoutes(c *mgo.Collection, mux *triemux.Mux, backends map[string]http.Ha
 	iter := c.Find(nil).Sort("incoming_path", "route_type").Iter()
 
 	goneHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusGone)
+		http.Error(w, "410 gone", http.StatusGone)
 	})
 
 	for iter.Next(&route) {


### PR DESCRIPTION
This makes is more consistent with the 404 handler, and helps see what's
going on when running in development.  In production these responses
will still be intercepted downstream and replaced with the proper error
page.

This also updates the router to use the same handler for all gone routes, which is a little more efficient.