### PR TITLE
Fix Makefile race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,24 +5,22 @@ BUILDFILES := router.go main.go router_api.go
 IMPORT_BASE := github.com/alphagov
 IMPORT_PATH := $(IMPORT_BASE)/router
 
-build: _vendor
+build: _vendor/stamp
 	gom build -o $(BINARY) $(BUILDFILES)
 
-run: _vendor
+run: _vendor/stamp
 	gom run $(BUILDFILES)
 
-test: _vendor build
+test: _vendor/stamp build
 	gom test ./trie ./triemux
 	gom test -v ./integration_tests
 
 clean:
 	rm -f $(BINARY)
 
-_vendor: Gomfile _vendor/src/$(IMPORT_PATH)
-	gom install
-	touch _vendor
-
-_vendor/src/$(IMPORT_PATH):
+_vendor/stamp: Gomfile
 	rm -f _vendor/src/$(IMPORT_PATH)
 	mkdir -p _vendor/src/$(IMPORT_BASE)
 	ln -s $(CURDIR) _vendor/src/$(IMPORT_PATH)
+	gom install
+	touch _vendor/stamp


### PR DESCRIPTION
Currently, if gom install errors or is aborted, the _vendor directory
will still get its timestamp updated. This means that future make runs
won't attempt to re-run gom install.

This changes the _vendor make target to use a stamp file to avoid this
issue.  It also combines the task for the project importpath into the
main task to avoid needlessly rerunning gom install every time the
to-level directory's timestamp is updated.