### PR TITLE
Return a 503 when running with no routes.

### DIFF
--- a/integration_tests/backend_selection_test.go
+++ b/integration_tests/backend_selection_test.go
@@ -10,15 +10,6 @@ import (
 
 var _ = Describe("Backend selection", func() {
 
-	It("should 404 with no routes", func() {
-		reloadRoutes()
-		resp := routerRequest("/")
-		Expect(resp.StatusCode).To(Equal(404))
-
-		resp = routerRequest("/foo")
-		Expect(resp.StatusCode).To(Equal(404))
-	})
-
 	Describe("simple exact routes", func() {
 		var (
 			backend1 *httptest.Server

--- a/integration_tests/error_handling_test.go
+++ b/integration_tests/error_handling_test.go
@@ -9,6 +9,20 @@ import (
 
 var _ = Describe("error handling", func() {
 
+	Describe("handling an empty routing table", func() {
+		BeforeEach(func() {
+			reloadRoutes()
+		})
+
+		It("should return a 503 error to the client", func() {
+			resp := routerRequest("/")
+			Expect(resp.StatusCode).To(Equal(503))
+
+			resp = routerRequest("/foo")
+			Expect(resp.StatusCode).To(Equal(503))
+		})
+	})
+
 	Describe("handling a panic", func() {
 		BeforeEach(func() {
 			addRoute("/boom", map[string]interface{}{"handler": "boom"})

--- a/triemux/mux.go
+++ b/triemux/mux.go
@@ -33,7 +33,14 @@ func NewMux() *Mux {
 
 // ServeHTTP dispatches the request to a backend with a registered route
 // matching the request path, or 404s.
+//
+// If the routing table is empty, return a 503.
 func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if mux.count == 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
 	handler, ok := mux.lookup(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)


### PR DESCRIPTION
If the connection to Mongodb fails when the router first starts up, it
will come up with an empty routing table.  Previously this would return
a 404 for all requests.  These would be served to end users and cached
upstream.

Running with an empty routing table is always going to be erroneous, so
this changes it to return a 503's in this situation. This will cause
upstream caches to serve from stale, and additionally won't be cached
anywhere.