### PR TITLE
Add version information to help output. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 .PHONY: build run test clean
 
 BINARY := router
-BUILDFILES := router.go main.go router_api.go
+BUILDFILES := router.go main.go router_api.go version.go
 IMPORT_BASE := github.com/alphagov
 IMPORT_PATH := $(IMPORT_BASE)/router
 
+ifdef RELEASE_VERSION
+VERSION := $(RELEASE_VERSION)
+else
+VERSION := $(shell git describe --always | tr -d '\n'; test -z "`git status --porcelain`" || echo '-dirty')
+endif
+
 build: _vendor/stamp
-	gom build -o $(BINARY) $(BUILDFILES)
+	gom build -ldflags "-X main.version $(VERSION)" -o $(BINARY) $(BUILDFILES)
 
 run: _vendor/stamp
 	gom run $(BUILDFILES)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,3 +4,4 @@ set -eu
 
 make
 make test
+./router -version

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 
 func usage() {
 	helpstring := `
+GOV.UK Router %s
 Usage: %s
 
 The following environment variables and defaults are available:
@@ -41,7 +42,7 @@ Timeouts: (values must be parseable by http://golang.org/pkg/time/#ParseDuration
 ROUTER_BACKEND_CONNECT_TIMEOUT=1s  Connect timeout when connecting to backends
 ROUTER_BACKEND_HEADER_TIMEOUT=15s  Timeout for backend response headers to be returned
 `
-	fmt.Fprintf(os.Stderr, helpstring, os.Args[0])
+	fmt.Fprintf(os.Stderr, helpstring, versionInfo(), os.Args[0])
 	os.Exit(2)
 }
 

--- a/main.go
+++ b/main.go
@@ -24,8 +24,9 @@ var (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s\n", os.Args[0])
 	helpstring := `
+Usage: %s
+
 The following environment variables and defaults are available:
 
 ROUTER_PUBADDR=:8080        Address on which to serve public requests
@@ -40,7 +41,7 @@ Timeouts: (values must be parseable by http://golang.org/pkg/time/#ParseDuration
 ROUTER_BACKEND_CONNECT_TIMEOUT=1s  Connect timeout when connecting to backends
 ROUTER_BACKEND_HEADER_TIMEOUT=15s  Timeout for backend response headers to be returned
 `
-	fmt.Fprintf(os.Stderr, helpstring)
+	fmt.Fprintf(os.Stderr, helpstring, os.Args[0])
 	os.Exit(2)
 }
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 func usage() {
 	helpstring := `
 GOV.UK Router %s
-Usage: %s
+Usage: %s [-version]
 
 The following environment variables and defaults are available:
 
@@ -78,6 +78,14 @@ func catchListenAndServe(addr string, handler http.Handler, ident string, wg *sy
 }
 
 func main() {
+	returnVersion := flag.Bool("version", false, "")
+	flag.Usage = usage
+	flag.Parse()
+	if *returnVersion {
+		fmt.Printf("GOV.UK Router %s\n", versionInfo())
+		os.Exit(0)
+	}
+
 	if os.Getenv("GOMAXPROCS") == "" {
 		// Use all available cores if not otherwise specified
 		runtime.GOMAXPROCS(runtime.NumCPU())
@@ -90,9 +98,6 @@ func main() {
 	if wd := os.Getenv("GOVUK_APP_ROOT"); wd != "" {
 		tablecloth.WorkingDir = wd
 	}
-
-	flag.Usage = usage
-	flag.Parse()
 
 	rout, err := NewRouter(mongoURL, mongoDbName, backendConnectTimeout, backendHeaderTimeout, errorLogFile)
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// populated by -ldflags from Makefile
+var version = "unknown"
+
+func versionInfo() string {
+	return fmt.Sprintf("build: %s (compiler: %s)", version, runtime.Version())
+}


### PR DESCRIPTION
This will allow us to determine what version of the router a given
binary is, and additionally, which version of Go was used to compile it.