### PR TITLE
Rate-limit route reloading.

### DIFF
--- a/integration_tests/reload_api_test.go
+++ b/integration_tests/reload_api_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"crypto/sha1"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,6 +31,34 @@ var _ = Describe("reload API endpoint", func() {
 			resp := doRequest(newRequest("GET", routerAPIURL("/reload")))
 			Expect(resp.StatusCode).To(Equal(405))
 			Expect(resp.Header.Get("Allow")).To(Equal("POST"))
+		})
+
+		Context("with a non-zero reload interval", func() {
+			newRouterPort := 7999
+			newApiPort := 8000
+			BeforeEach(func() {
+				err := startRouter(newRouterPort, newApiPort, map[string]string{"ROUTER_RELOAD_INTERVAL": "1s"})
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				stopRouter(newRouterPort)
+			})
+
+			It("should return 'already in progress' for requests within timeout", func() {
+				resp := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				resp2 := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				Expect(readBody(resp)).To(Equal("Reload triggered"))
+				Expect(readBody(resp2)).To(Equal("Reload already in progress"))
+			})
+
+			It("should return 'triggered' for requests after timeout", func() {
+				resp := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				time.Sleep(time.Second * 2)
+				resp2 := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				Expect(readBody(resp)).To(Equal("Reload triggered"))
+				Expect(readBody(resp2)).To(Equal("Reload triggered"))
+			})
 		})
 	})
 

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -32,6 +32,9 @@ func reloadRoutes(optionalPort ...int) {
 	resp, err := http.Post(fmt.Sprintf("http://localhost:%d/reload", port), "", nil)
 	Expect(err).To(BeNil())
 	Expect(resp.StatusCode).To(Equal(200))
+	// Now that reloading is done asynchronously, we need a small sleep to ensure
+	// it has actually been performed.
+	time.Sleep(time.Millisecond * 50)
 }
 
 var runningRouters = make(map[int]*exec.Cmd)
@@ -47,6 +50,7 @@ func startRouter(port, apiPort int, optionalExtraEnv ...envMap) error {
 	env["ROUTER_APIADDR"] = apiaddr
 	env["ROUTER_MONGO_DB"] = "router_test"
 	env["ROUTER_ERROR_LOG"] = tempLogfile.Name()
+	env["ROUTER_RELOAD_INTERVAL"] = "0s"
 	if len(optionalExtraEnv) > 0 {
 		for k, v := range optionalExtraEnv[0] {
 			env[k] = v

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var (
 	enableDebugOutput     = os.Getenv("DEBUG") != ""
 	backendConnectTimeout = getenvDefault("ROUTER_BACKEND_CONNECT_TIMEOUT", "1s")
 	backendHeaderTimeout  = getenvDefault("ROUTER_BACKEND_HEADER_TIMEOUT", "15s")
+	reloadInterval        = getenvDefault("ROUTER_RELOAD_INTERVAL", "1s")
 )
 
 func usage() {
@@ -39,6 +40,7 @@ Timeouts: (values must be parseable by http://golang.org/pkg/time/#ParseDuration
 
 ROUTER_BACKEND_CONNECT_TIMEOUT=1s  Connect timeout when connecting to backends
 ROUTER_BACKEND_HEADER_TIMEOUT=15s  Timeout for backend response headers to be returned
+ROUTER_RELOAD_INTERVAL=1s          Interval for route reloading rate limit
 `
 	fmt.Fprintf(os.Stderr, helpstring)
 	os.Exit(2)
@@ -103,7 +105,10 @@ func main() {
 	go catchListenAndServe(pubAddr, rout, "proxy", wg)
 	logInfo("router: listening for requests on " + pubAddr)
 
-	api := newAPIHandler(rout)
+	api, err := newAPIHandler(rout)
+	if err != nil {
+		log.Fatal(err)
+	}
 	go catchListenAndServe(apiAddr, api, "api", wg)
 	logInfo("router: listening for refresh on " + apiAddr)
 

--- a/router_api.go
+++ b/router_api.go
@@ -4,9 +4,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"runtime"
+	"time"
 )
 
-func newAPIHandler(rout *Router) http.Handler {
+func newAPIHandler(rout *Router) (api http.Handler, err error) {
+	reloadDuration, err := time.ParseDuration(reloadInterval)
+	if err != nil {
+		return nil, err
+	}
+	reloadChan := make(chan bool)
+	go func() {
+		// Rate-limit reloads to 1 per RELOAD_INTERVAL.
+		// This goroutine blocks until it receives a message on reloadChan, then
+		// waits for the timeout before calling reload.
+		for range reloadChan {
+			time.Sleep(reloadDuration)
+			rout.ReloadRoutes()
+		}
+	}()
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/reload", func(w http.ResponseWriter, r *http.Request) {
@@ -15,8 +31,16 @@ func newAPIHandler(rout *Router) http.Handler {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-
-		rout.ReloadRoutes()
+		// Send a message to the reload goroutine, which will start a new timeout
+		// before reloading, or do nothing if one is already in progress.
+		select {
+		case reloadChan <- true:
+			logInfo("router: reload triggered")
+			w.Write([]byte("Reload triggered"))
+		default:
+			logInfo("router: reload already in progress")
+			w.Write([]byte("Reload already in progress"))
+		}
 	})
 	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
@@ -65,5 +89,5 @@ func newAPIHandler(rout *Router) http.Handler {
 		w.Write([]byte("\n"))
 	})
 
-	return mux
+	return mux, nil
 }


### PR DESCRIPTION
Although ReloadRoutes ensures that routes continue to be served while they are being reloaded, the reload itself still takes some time, and the client making the request will be blocked until the reload is complete. This means for example that content-store can become unresponsive when it tries to register a large number of routes. 

This change implements a rate limit, set by the ROUTER_RELOAD_INTERVAL env var (default 1s), so that a reload request waits for that interval before doing the actual reload, and any further requests within that time do not trigger an extra reload.

Local testing shows that this speeds up the general time to register 900 content items by about 15%, but it's not possible in that environment to test how it affects the responsiveness of content-store in this scenario - that may need to be done in preview.