### PR TITLE
Reduce redirect cache TTL to 30 mins.

### DIFF
--- a/handlers/redirect_handler.go
+++ b/handlers/redirect_handler.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const cacheDuration = 24 * time.Hour
+const cacheDuration = 30 * time.Minute
 
 func NewRedirectHandler(source, target string, prefix, temporary bool) http.Handler {
 	statusMoved := http.StatusMovedPermanently

--- a/integration_tests/redirect_test.go
+++ b/integration_tests/redirect_test.go
@@ -48,15 +48,15 @@ var _ = Describe("Redirection", func() {
 			Expect(resp.Header.Get("Location")).To(Equal("/bar#section"))
 		})
 
-		It("should contain cache headers of 24hrs", func() {
+		It("should contain cache headers of 30 mins", func() {
 			resp := routerRequest("/foo")
-			Expect(resp.Header.Get("Cache-Control")).To(Equal("max-age=86400, public"))
+			Expect(resp.Header.Get("Cache-Control")).To(Equal("max-age=1800, public"))
 
 			Expect(
 				time.Parse(time.RFC1123, resp.Header.Get("Expires")),
 			).To(BeTemporally(
 				"~",
-				time.Now().Add(24*time.Hour),
+				time.Now().Add(30*time.Minute),
 				time.Second,
 			))
 		})
@@ -91,15 +91,15 @@ var _ = Describe("Redirection", func() {
 			Expect(resp.Header.Get("Location")).To(Equal("/bar?baz=qux"))
 		})
 
-		It("should contain cache headers of 24hrs", func() {
+		It("should contain cache headers of 30 mins", func() {
 			resp := routerRequest("/foo")
-			Expect(resp.Header.Get("Cache-Control")).To(Equal("max-age=86400, public"))
+			Expect(resp.Header.Get("Cache-Control")).To(Equal("max-age=1800, public"))
 
 			Expect(
 				time.Parse(time.RFC1123, resp.Header.Get("Expires")),
 			).To(BeTemporally(
 				"~",
-				time.Now().Add(24*time.Hour),
+				time.Now().Add(30*time.Minute),
 				time.Second,
 			))
 		})


### PR DESCRIPTION
The current cache TTL of 1 day can cause problems when redirects are
changed, or even replaced with a regular route.

Reducing this to 30 minutes will make it less surprising (it's more
consistent with the rest of the stack). It shouldn't make much
difference to the load on the servers because redirects are very
cheap to serve.