### PR TITLE
Add test for HTTPS backends

### DIFF
--- a/handlers/backend_handler.go
+++ b/handlers/backend_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/alphagov/router/logger"
 )
+
+var TLSSkipVerify bool
 
 func NewBackendHandler(backendURL *url.URL, connectTimeout, headerTimeout time.Duration, logger logger.Logger) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
@@ -64,6 +67,11 @@ func newBackendTransport(connectTimeout, headerTimeout time.Duration, logger log
 	// per upstream.
 	transport.wrapped.MaxIdleConnsPerHost = 20
 	transport.wrapped.ResponseHeaderTimeout = headerTimeout
+
+	if TLSSkipVerify {
+		transport.wrapped.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
 	return
 }
 

--- a/integration_tests/backend_helpers.go
+++ b/integration_tests/backend_helpers.go
@@ -42,7 +42,20 @@ func startTarpitBackend(delays ...time.Duration) *httptest.Server {
 }
 
 func startRecordingBackend() *ghttp.Server {
-	server := ghttp.NewServer()
+	return startRecordingServer(false)
+}
+
+func startRecordingTLSBackend() *ghttp.Server {
+	return startRecordingServer(true)
+}
+
+func startRecordingServer(tls bool) (server *ghttp.Server) {
+	if tls {
+		server = ghttp.NewTLSServer()
+	} else {
+		server = ghttp.NewServer()
+	}
+
 	server.AllowUnhandledRequests = true
 	server.UnhandledRequestStatusCode = http.StatusOK
 	return server

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/alext/tablecloth"
+	"github.com/alphagov/router/handlers"
 )
 
 var (
@@ -18,6 +19,7 @@ var (
 	mongoURL              = getenvDefault("ROUTER_MONGO_URL", "localhost")
 	mongoDbName           = getenvDefault("ROUTER_MONGO_DB", "router")
 	errorLogFile          = getenvDefault("ROUTER_ERROR_LOG", "STDERR")
+	tlsSkipVerify         = os.Getenv("ROUTER_TLS_SKIP_VERIFY") != ""
 	enableDebugOutput     = os.Getenv("DEBUG") != ""
 	backendConnectTimeout = getenvDefault("ROUTER_BACKEND_CONNECT_TIMEOUT", "1s")
 	backendHeaderTimeout  = getenvDefault("ROUTER_BACKEND_HEADER_TIMEOUT", "15s")
@@ -91,6 +93,12 @@ func main() {
 		runtime.GOMAXPROCS(runtime.NumCPU())
 	}
 	logInfo(fmt.Sprintf("router: using GOMAXPROCS value of %d", runtime.GOMAXPROCS(0)))
+
+	if tlsSkipVerify {
+		handlers.TLSSkipVerify = true
+		logWarn("router: Skipping verification of TLS certificates. " +
+			"Do not use this option in a production environment.")
+	}
 
 	// Set working dir for tablecloth if available This is to allow restarts to
 	// pick up new versions.


### PR DESCRIPTION
Add a test to verify that the router can connect to a HTTPS backend.

For this, add the `ROUTER_TLS_SKIP_VERIFY` environment variable, which
will cause the router to skip verification of backend TLS certificates
when set to a non-empty value.

This option is only intended for use by the tests. We were hesitant to
do this given that disabling TLS verification adjusts the normal
application behaviour, however we decided this is an acceptable
compromise given that we're testing the TLS transport, not the
verification of TLS certificates (though we may later decide to test for
that separately).

Log a warning when `ROUTER_TLS_SKIP_VERIFY` is enabled to make it clear
that it is not intended for production use.