### PR TITLE
Bump tablecloth version.

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,5 +1,5 @@
 gom 'gopkg.in/mgo.v2', :tag => 'r2015.01.24'
-gom 'github.com/alext/tablecloth', :commit => 'b373a9a'
+gom 'github.com/alext/tablecloth', :commit => 'fbddb1a'
 
 gom 'github.com/onsi/ginkgo', :tag => 'v1.1.0'
 gom 'github.com/onsi/gomega', :tag => 'v1.0'


### PR DESCRIPTION
The updated version includes fixes for a couple of file descriptor
leaks. It also makes it abort a reload if the new server fails to start.

https://github.com/alext/tablecloth/compare/b373a9a...fbddb1a