### PR TITLE
Fix dependency installation.

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -3,4 +3,7 @@ gom 'github.com/alext/tablecloth', :commit => 'fbddb1a'
 
 gom 'github.com/onsi/ginkgo', :tag => 'v1.1.0'
 gom 'github.com/onsi/gomega', :tag => 'v1.0'
+
+# Dependency of vegeta
+gom 'github.com/bmizerany/perks/quantile', :commit => 'd9a9656'
 gom 'github.com/tsenart/vegeta', :tag => 'v5.4.0'


### PR DESCRIPTION
The build is currently failing on master because it can't find quantile
(a dependency of vegeta). I'm not sure why this was working before, and
has stopped now, but we should be pinning this anyway.

This should fix build failures like https://ci-new.alphagov.co.uk/job/govuk_router/114/console