### PR TITLE
Support special characters (eg space) in paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ The `routes` collection uses the following data structure:
 }
 ```
 
+Incoming paths with special characters must be in their % encoded form in the
+database (eg spaces must be stored as `%20`).
+
 The behaviour is determined by `handler`. See below for extra fields
 corresponding to `handler` types.
 

--- a/integration_tests/redirect_test.go
+++ b/integration_tests/redirect_test.go
@@ -103,6 +103,15 @@ var _ = Describe("Redirection", func() {
 				time.Second,
 			))
 		})
+
+		It("should handle path-preserving redirects with special characters", func() {
+			addRedirectRoute("/foo%20bar", "/bar%20baz", "prefix")
+			reloadRoutes()
+
+			resp := routerRequest("/foo bar/something")
+			Expect(resp.StatusCode).To(Equal(301))
+			Expect(resp.Header.Get("Location")).To(Equal("/bar%20baz/something"))
+		})
 	})
 
 	Describe("external redirects", func() {

--- a/integration_tests/route_selection_test.go
+++ b/integration_tests/route_selection_test.go
@@ -353,4 +353,26 @@ var _ = Describe("Route selection", func() {
 			Expect(recorder.ReceivedRequests()[0].URL.Path).To(Equal("/foo//bar"))
 		})
 	})
+
+	Describe("special characters in paths", func() {
+		var recorder *ghttp.Server
+
+		BeforeEach(func() {
+			recorder = startRecordingBackend()
+			addBackend("backend", recorder.URL())
+		})
+		AfterEach(func() {
+			recorder.Close()
+		})
+
+		It("should handle spaces (%20) in paths", func() {
+			addBackendRoute("/foo%20bar", "backend")
+			reloadRoutes()
+
+			resp := routerRequest("/foo bar")
+			Expect(resp.StatusCode).To(Equal(200))
+			Expect(recorder.ReceivedRequests()).To(HaveLen(1))
+			Expect(recorder.ReceivedRequests()[0].RequestURI).To(Equal("/foo%20bar"))
+		})
+	})
 })

--- a/integration_tests/route_selection_test.go
+++ b/integration_tests/route_selection_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onsi/gomega/ghttp"
 )
 
-var _ = Describe("Backend selection", func() {
+var _ = Describe("Route selection", func() {
 
 	Describe("simple exact routes", func() {
 		var (


### PR DESCRIPTION
The database contains these special routes in their %-encoded form, but
the paths we were comparing against were in their decoded form, and
therefore didn't match. This updates our matching code to decode the
paths from the database before comparing against the request URL so that
we're comparing equivalent forms.

This is needed to support some redirects for common typos (eg `/vehicle tax`).

/cc @jamiecobbett 

Fixes #96