### PR TITLE
Add support for disabled routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,19 @@ The `routes` collection uses the following data structure:
   "route_type"    : ["prefix","exact"],
   "incoming_path" : "/url-path/here",
   "handler"       : ["backend", "redirect", "gone"],
+  "disabled"      : false
 }
 ```
 
 Incoming paths with special characters must be in their % encoded form in the
 database (eg spaces must be stored as `%20`).
 
-The behaviour is determined by `handler`. See below for extra fields
-corresponding to `handler` types.
+The behaviour of an enabled route is determined by `handler`. See below for
+extra fields corresponding to `handler` types.
+
+If a route is disabled, the router will return a 503 for all matching requests.
+This is typically used if a service needs to be taken offline for maintenance
+etc.
 
 #### `backend` handler
 

--- a/integration_tests/disabled_routes_test.go
+++ b/integration_tests/disabled_routes_test.go
@@ -1,0 +1,28 @@
+package integration
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("marking routes as disabled", func() {
+
+	Describe("handling a disabled route", func() {
+		BeforeEach(func() {
+			addRoute("/unavailable", map[string]interface{}{"handler": "gone", "disabled": true})
+			addRedirectRoute("/something-live", "/somewhere-else")
+			reloadRoutes()
+		})
+
+		It("should return a 503 to the client", func() {
+			resp := routerRequest("/unavailable")
+			Expect(resp.StatusCode).To(Equal(503))
+		})
+
+		It("should continue to route other requests", func() {
+			resp := routerRequest("/something-live")
+			Expect(resp.StatusCode).To(Equal(301))
+			Expect(resp.Header.Get("Location")).To(Equal("/somewhere-else"))
+		})
+	})
+})


### PR DESCRIPTION
This allows a route to be flagged as disabled. In this case, the router
will return a 503 for all matching requests. This is occasionally needed
if we need to take a service offline for maintenance etc.

Pivotal: https://www.pivotaltracker.com/story/show/102736052