### PR TITLE
Add new behaviour for prefix redirects

### DIFF
--- a/handlers/redirect_handler.go
+++ b/handlers/redirect_handler.go
@@ -14,7 +14,7 @@ func NewRedirectHandler(source, target string, prefix bool, preserve bool, tempo
 	if temporary {
 		statusMoved = http.StatusFound
 	}
-	if prefix && preserve {
+	if preserve {
 		return &pathPreservingRedirectHandler{source, target, statusMoved}
 	}
 	return &redirectHandler{target, statusMoved}

--- a/handlers/redirect_handler.go
+++ b/handlers/redirect_handler.go
@@ -20,9 +20,9 @@ func NewRedirectHandler(source, target string, prefix bool, preserve bool, tempo
 	return &redirectHandler{target, statusMoved}
 }
 
-func addCacheHeaders(w http.ResponseWriter) {
-	w.Header().Set("Expires", time.Now().Add(cacheDuration).Format(time.RFC1123))
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public", cacheDuration/time.Second))
+func addCacheHeaders(writer http.ResponseWriter) {
+	writer.Header().Set("Expires", time.Now().Add(cacheDuration).Format(time.RFC1123))
+	writer.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public", cacheDuration/time.Second))
 }
 
 type redirectHandler struct {
@@ -30,9 +30,9 @@ type redirectHandler struct {
 	code int
 }
 
-func (rh *redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	addCacheHeaders(w)
-	http.Redirect(w, r, rh.url, rh.code)
+func (handler *redirectHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	addCacheHeaders(writer)
+	http.Redirect(writer, request, handler.url, handler.code)
 }
 
 type pathPreservingRedirectHandler struct {
@@ -41,12 +41,12 @@ type pathPreservingRedirectHandler struct {
 	code         int
 }
 
-func (rh *pathPreservingRedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	target := rh.targetPrefix + strings.TrimPrefix(r.URL.Path, rh.sourcePrefix)
-	if r.URL.RawQuery != "" {
-		target = target + "?" + r.URL.RawQuery
+func (handler *pathPreservingRedirectHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	target := handler.targetPrefix + strings.TrimPrefix(request.URL.Path, handler.sourcePrefix)
+	if request.URL.RawQuery != "" {
+		target = target + "?" + request.URL.RawQuery
 	}
 
-	addCacheHeaders(w)
-	http.Redirect(w, r, target, rh.code)
+	addCacheHeaders(writer)
+	http.Redirect(writer, request, target, handler.code)
 }

--- a/handlers/redirect_handler.go
+++ b/handlers/redirect_handler.go
@@ -9,7 +9,7 @@ import (
 
 const cacheDuration = 30 * time.Minute
 
-func NewRedirectHandler(source, target string, prefix bool, preserve bool, temporary bool) http.Handler {
+func NewRedirectHandler(source, target string, preserve bool, temporary bool) http.Handler {
 	statusMoved := http.StatusMovedPermanently
 	if temporary {
 		statusMoved = http.StatusFound

--- a/handlers/redirect_handler.go
+++ b/handlers/redirect_handler.go
@@ -9,12 +9,12 @@ import (
 
 const cacheDuration = 30 * time.Minute
 
-func NewRedirectHandler(source, target string, prefix, temporary bool) http.Handler {
+func NewRedirectHandler(source, target string, prefix bool, preserve bool, temporary bool) http.Handler {
 	statusMoved := http.StatusMovedPermanently
 	if temporary {
 		statusMoved = http.StatusFound
 	}
-	if prefix {
+	if prefix && preserve {
 		return &pathPreservingRedirectHandler{source, target, statusMoved}
 	}
 	return &redirectHandler{target, statusMoved}

--- a/integration_tests/disabled_routes_test.go
+++ b/integration_tests/disabled_routes_test.go
@@ -9,8 +9,8 @@ var _ = Describe("marking routes as disabled", func() {
 
 	Describe("handling a disabled route", func() {
 		BeforeEach(func() {
-			addRoute("/unavailable", Route {Handler: "gone", Disabled: true})
-			addRedirectRoute("/something-live", "/somewhere-else")
+			addRoute("/unavailable", Route{Handler: "gone", Disabled: true})
+			addRoute("/something-live", NewRedirectRoute("/somewhere-else"))
 			reloadRoutes()
 		})
 

--- a/integration_tests/disabled_routes_test.go
+++ b/integration_tests/disabled_routes_test.go
@@ -9,7 +9,7 @@ var _ = Describe("marking routes as disabled", func() {
 
 	Describe("handling a disabled route", func() {
 		BeforeEach(func() {
-			addRoute("/unavailable", map[string]interface{}{"handler": "gone", "disabled": true})
+			addRoute("/unavailable", Route {Handler: "gone", Disabled: true})
 			addRedirectRoute("/something-live", "/somewhere-else")
 			reloadRoutes()
 		})

--- a/integration_tests/error_handling_test.go
+++ b/integration_tests/error_handling_test.go
@@ -25,7 +25,7 @@ var _ = Describe("error handling", func() {
 
 	Describe("handling a panic", func() {
 		BeforeEach(func() {
-			addRoute("/boom", map[string]interface{}{"handler": "boom"})
+			addRoute("/boom", Route {Handler: "boom"})
 			reloadRoutes()
 		})
 

--- a/integration_tests/error_handling_test.go
+++ b/integration_tests/error_handling_test.go
@@ -25,7 +25,7 @@ var _ = Describe("error handling", func() {
 
 	Describe("handling a panic", func() {
 		BeforeEach(func() {
-			addRoute("/boom", Route {Handler: "boom"})
+			addRoute("/boom", Route{Handler: "boom"})
 			reloadRoutes()
 		})
 

--- a/integration_tests/gone_test.go
+++ b/integration_tests/gone_test.go
@@ -8,8 +8,8 @@ import (
 var _ = Describe("Gone routes", func() {
 
 	BeforeEach(func() {
-		addGoneRoute("/foo")
-		addGoneRoute("/bar", "prefix")
+		addRoute("/foo", NewGoneRoute())
+		addRoute("/bar", NewGoneRoute("prefix"))
 		reloadRoutes()
 	})
 

--- a/integration_tests/performance_test.go
+++ b/integration_tests/performance_test.go
@@ -25,8 +25,8 @@ var _ = Describe("Performance", func() {
 			backend2 = startSimpleBackend("backend 2")
 			addBackend("backend-1", backend1.URL)
 			addBackend("backend-2", backend2.URL)
-			addBackendRoute("/one", "backend-1")
-			addBackendRoute("/two", "backend-2")
+			addRoute("/one", NewBackendRoute("backend-1"))
+			addRoute("/two", NewBackendRoute("backend-2"))
 			reloadRoutes()
 		})
 		AfterEach(func() {
@@ -62,7 +62,7 @@ var _ = Describe("Performance", func() {
 				slowBackend := startTarpitBackend(time.Second)
 				defer slowBackend.Close()
 				addBackend("backend-slow", slowBackend.URL)
-				addBackendRoute("/slow", "backend-slow")
+				addRoute("/slow", NewBackendRoute("backend-slow"))
 				reloadRoutes()
 
 				attacker := startVegetaLoad(routerURL("/slow"))
@@ -75,7 +75,7 @@ var _ = Describe("Performance", func() {
 		Describe("one downed backend hit separately", func() {
 			It("should not significantly increase latency", func() {
 				addBackend("backend-down", "http://localhost:3162/")
-				addBackendRoute("/down", "backend-down")
+				addRoute("/down", NewBackendRoute("backend-down"))
 				reloadRoutes()
 
 				attacker := startVegetaLoad(routerURL("/down"))
@@ -106,8 +106,8 @@ var _ = Describe("Performance", func() {
 				backend2 = startTarpitBackend(time.Second)
 				addBackend("backend-1", backend1.URL)
 				addBackend("backend-2", backend2.URL)
-				addBackendRoute("/one", "backend-1")
-				addBackendRoute("/two", "backend-2")
+				addRoute("/one", NewBackendRoute("backend-1"))
+				addRoute("/two", NewBackendRoute("backend-2"))
 				reloadRoutes()
 			})
 			AfterEach(func() {

--- a/integration_tests/proxy_function_test.go
+++ b/integration_tests/proxy_function_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 	Describe("connecting to the backend", func() {
 		It("should return a 502 if the connection to the backend is refused", func() {
 			addBackend("not-running", "http://127.0.0.1:3164/")
-			addBackendRoute("/not-running", "not-running")
+			addRoute("/not-running", NewBackendRoute("not-running"))
 			reloadRoutes()
 
 			req, err := http.NewRequest("GET", routerURL("/not-running"), nil)
@@ -49,7 +49,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 				startRouter(3167, 3166, envMap{"ROUTER_BACKEND_CONNECT_TIMEOUT": "0.3s"})
 				defer stopRouter(3167)
 				addBackend("firewall-blocked", "http://localhost:3170/")
-				addBackendRoute("/blocked", "firewall-blocked")
+				addRoute("/blocked", NewBackendRoute("firewall-blocked"))
 				reloadRoutes(3166)
 
 				req, err := http.NewRequest("GET", routerURL("/blocked", 3167), nil)
@@ -90,8 +90,8 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 				tarpit2 = startTarpitBackend(100*time.Millisecond, 500*time.Millisecond)
 				addBackend("tarpit1", tarpit1.URL)
 				addBackend("tarpit2", tarpit2.URL)
-				addBackendRoute("/tarpit1", "tarpit1")
-				addBackendRoute("/tarpit2", "tarpit2")
+				addRoute("/tarpit1", NewBackendRoute("tarpit1"))
+				addRoute("/tarpit2", NewBackendRoute("tarpit2"))
 				reloadRoutes(3166)
 			})
 
@@ -138,7 +138,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 			recorder = startRecordingBackend()
 			recorderURL, _ = url.Parse(recorder.URL())
 			addBackend("backend", recorder.URL())
-			addBackendRoute("/foo", "backend", "prefix")
+			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes()
 		})
 
@@ -263,7 +263,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 		BeforeEach(func() {
 			recorder = startRecordingBackend()
 			addBackend("backend", recorder.URL())
-			addBackendRoute("/foo", "backend", "prefix")
+			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes()
 		})
 
@@ -323,7 +323,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 		BeforeEach(func() {
 			recorder = startRecordingBackend()
 			addBackend("backend", recorder.URL()+"/something")
-			addBackendRoute("/foo/bar", "backend", "prefix")
+			addRoute("/foo/bar", NewBackendRoute("backend", "prefix"))
 			reloadRoutes()
 		})
 
@@ -358,7 +358,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 		BeforeEach(func() {
 			recorder = startRecordingBackend()
 			addBackend("backend", recorder.URL())
-			addBackendRoute("/foo", "backend", "prefix")
+			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes()
 		})
 
@@ -394,7 +394,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 			startRouter(3167, 3166, envMap{"ROUTER_TLS_SKIP_VERIFY": "1"})
 			recorder = startRecordingTLSBackend()
 			addBackend("backend", recorder.URL())
-			addBackendRoute("/foo", "backend", "prefix")
+			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes(3166)
 		})
 

--- a/integration_tests/redirect_test.go
+++ b/integration_tests/redirect_test.go
@@ -11,10 +11,10 @@ var _ = Describe("Redirection", func() {
 
 	Describe("exact redirects", func() {
 		BeforeEach(func() {
-			addRedirectRoute("/foo", "/bar")
-			addRedirectRoute("/foo-temp", "/bar", "exact", "temporary")
-			addRedirectRoute("/query-temp", "/bar?query=true", "exact")
-			addRedirectRoute("/fragment", "/bar#section", "exact")
+			addRoute("/foo", NewRedirectRoute("/bar"))
+			addRoute("/foo-temp", NewRedirectRoute("/bar", "exact", "temporary"))
+			addRoute("/query-temp", NewRedirectRoute("/bar?query=true", "exact"))
+			addRoute("/fragment", NewRedirectRoute("/bar#section", "exact"))
 			reloadRoutes()
 		})
 
@@ -64,8 +64,8 @@ var _ = Describe("Redirection", func() {
 
 	Describe("prefix redirects", func() {
 		BeforeEach(func() {
-			addRedirectRoute("/foo", "/bar", "prefix")
-			addRedirectRoute("/foo-temp", "/bar-temp", "prefix", "temporary")
+			addRoute("/foo", NewRedirectRoute("/bar", "prefix"))
+			addRoute("/foo-temp", NewRedirectRoute("/bar-temp", "prefix", "temporary"))
 			reloadRoutes()
 		})
 
@@ -105,7 +105,7 @@ var _ = Describe("Redirection", func() {
 		})
 
 		It("should handle path-preserving redirects with special characters", func() {
-			addRedirectRoute("/foo%20bar", "/bar%20baz", "prefix")
+			addRoute("/foo%20bar", NewRedirectRoute("/bar%20baz", "prefix"))
 			reloadRoutes()
 
 			resp := routerRequest("/foo bar/something")
@@ -116,8 +116,8 @@ var _ = Describe("Redirection", func() {
 
 	Describe("external redirects", func() {
 		BeforeEach(func() {
-			addRedirectRoute("/foo", "http://foo.example.com/foo")
-			addRedirectRoute("/bar", "http://bar.example.com/bar", "prefix")
+			addRoute("/foo", NewRedirectRoute("http://foo.example.com/foo"))
+			addRoute("/bar", NewRedirectRoute("http://bar.example.com/bar", "prefix"))
 			reloadRoutes()
 		})
 

--- a/integration_tests/redirect_test.go
+++ b/integration_tests/redirect_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Redirection", func() {
 		BeforeEach(func() {
 			addRoute("/foo", NewRedirectRoute("/bar", "prefix"))
 			addRoute("/foo-temp", NewRedirectRoute("/bar-temp", "prefix", "temporary"))
+			addRoute("/qux", NewRedirectRoute("/baz", "prefix", "temporary", "ignore"))
 			reloadRoutes()
 		})
 
@@ -84,6 +85,11 @@ var _ = Describe("Redirection", func() {
 		It("should preserve extra path sections when redirecting", func() {
 			resp := routerRequest("/foo/baz")
 			Expect(resp.Header.Get("Location")).To(Equal("/bar/baz"))
+		})
+
+		It("should ignore extra path sections when redirecting if specified", func() {
+			resp := routerRequest("/qux/quux")
+			Expect(resp.Header.Get("Location")).To(Equal("/baz"))
 		})
 
 		It("should preserve the query string when redirecting", func() {
@@ -118,6 +124,7 @@ var _ = Describe("Redirection", func() {
 		BeforeEach(func() {
 			addRoute("/foo", NewRedirectRoute("http://foo.example.com/foo"))
 			addRoute("/bar", NewRedirectRoute("http://bar.example.com/bar", "prefix"))
+			addRoute("/qux", NewRedirectRoute("http://bar.example.com/qux", "prefix", "permanent", "ignore"))
 			reloadRoutes()
 		})
 
@@ -142,6 +149,11 @@ var _ = Describe("Redirection", func() {
 			It("should preserve extra path sections when redirecting", func() {
 				resp := routerRequest("/bar/baz")
 				Expect(resp.Header.Get("Location")).To(Equal("http://bar.example.com/bar/baz"))
+			})
+
+			It("should ignore extra path sections when redirecting if specified", func() {
+				resp := routerRequest("/qux/baz")
+				Expect(resp.Header.Get("Location")).To(Equal("http://bar.example.com/qux"))
 			})
 
 			It("should preserve the query string when redirecting", func() {

--- a/integration_tests/reload_api_test.go
+++ b/integration_tests/reload_api_test.go
@@ -53,9 +53,9 @@ var _ = Describe("reload API endpoint", func() {
 			var data map[string]map[string]interface{}
 
 			BeforeEach(func() {
-				addRedirectRoute("/foo", "/bar", "prefix")
-				addRedirectRoute("/baz", "/qux", "prefix")
-				addRedirectRoute("/foo", "/bar/baz")
+				addRoute("/foo", NewRedirectRoute("/bar", "prefix"))
+				addRoute("/baz", NewRedirectRoute("/qux", "prefix"))
+				addRoute("/foo", NewRedirectRoute("/bar/baz"))
 				reloadRoutes()
 				resp := doRequest(newRequest("GET", routerAPIURL("/stats")))
 				Expect(resp.StatusCode).To(Equal(200))
@@ -105,9 +105,9 @@ var _ = Describe("reload API endpoint", func() {
 
 	Describe("memory stats", func() {
 		It("should return memory statistics", func() {
-			addRedirectRoute("/foo", "/bar", "prefix")
-			addRedirectRoute("/baz", "/qux", "prefix")
-			addRedirectRoute("/foo", "/bar/baz")
+			addRoute("/foo", NewRedirectRoute("/bar", "prefix"))
+			addRoute("/baz", NewRedirectRoute("/qux", "prefix"))
+			addRoute("/foo", NewRedirectRoute("/bar/baz"))
 			reloadRoutes()
 
 			resp := doRequest(newRequest("GET", routerAPIURL("/memory-stats")))

--- a/integration_tests/route_helpers.go
+++ b/integration_tests/route_helpers.go
@@ -16,6 +16,44 @@ var (
 	routerDB *mgo.Database
 )
 
+type Route struct {
+	IncomingPath string `bson:"incoming_path"`
+	RouteType    string `bson:"route_type"`
+	Handler      string `bson:"handler"`
+	BackendID    string `bson:"backend_id"`
+	RedirectTo   string `bson:"redirect_to"`
+	RedirectType string `bson:"redirect_type"`
+	Disabled     bool   `bson:"disabled"`
+}
+
+func NewBackendRoute(backendID string) Route {
+	route := Route {
+		Handler: "backend",
+		BackendID: backendID,
+	}
+
+	return route
+}
+
+func NewRedirectRoute(redirectTo string) Route {
+	route := Route {
+		Handler: "redirect",
+		RedirectTo: redirectTo,
+		RedirectType: "permanent",
+		RouteType: "exact",
+	}
+
+	return route
+}
+
+func NewGoneRoute() Route {
+	route := Route {
+		Handler: "gone",
+	}
+
+	return route
+}
+
 func init() {
 	sess, err := mgo.Dial("localhost")
 	if err != nil {
@@ -30,36 +68,42 @@ func addBackend(id, url string) {
 }
 
 func addBackendRoute(path, backendID string, possibleRouteType ...string) {
-	route := bson.M{
-		"handler":    "backend",
-		"backend_id": backendID,
+	route := NewBackendRoute(backendID)
+
+	if len(possibleRouteType) > 0 {
+		route.RouteType = possibleRouteType[0]
 	}
-	addRoute(path, route, possibleRouteType...)
+
+	addRoute(path, route)
 }
 
-func addRedirectRoute(path, destination string, extraParams ...string) {
-	route := bson.M{
-		"handler":     "redirect",
-		"redirect_to": destination,
+func addRedirectRoute(path, redirectTo string, extraParams ...string) {
+	route := NewRedirectRoute(redirectTo)
+
+	if len(extraParams) > 0 {
+		route.RouteType = extraParams[0]
 	}
-	// extraParams[0] handled by addRoute
 	if len(extraParams) > 1 {
-		route["redirect_type"] = extraParams[1]
+		route.RedirectType = extraParams[1]
 	}
-	addRoute(path, route, extraParams...)
+
+	addRoute(path, route)
 }
 
 func addGoneRoute(path string, possibleRouteType ...string) {
-	addRoute(path, bson.M{"handler": "gone"}, possibleRouteType...)
+	route := NewGoneRoute()
+
+	if len(possibleRouteType) > 0 {
+		route.RouteType = possibleRouteType[0]
+	}
+
+	addRoute(path, route)
 }
 
-func addRoute(path string, details bson.M, possibleRouteType ...string) {
-	details["incoming_path"] = path
-	details["route_type"] = "exact"
-	if len(possibleRouteType) > 0 {
-		details["route_type"] = possibleRouteType[0]
-	}
-	err := routerDB.C("routes").Insert(details)
+func addRoute(path string, route Route) {
+	route.IncomingPath = path
+
+	err := routerDB.C("routes").Insert(route)
 	Expect(err).To(BeNil())
 }
 

--- a/integration_tests/route_helpers.go
+++ b/integration_tests/route_helpers.go
@@ -23,6 +23,7 @@ type Route struct {
 	BackendID    string `bson:"backend_id"`
 	RedirectTo   string `bson:"redirect_to"`
 	RedirectType string `bson:"redirect_type"`
+	PrefixMode   string `bson:"prefix_mode"`
 	Disabled     bool   `bson:"disabled"`
 }
 
@@ -45,6 +46,7 @@ func NewRedirectRoute(redirectTo string, extraParams ...string) Route {
 		RedirectTo:   redirectTo,
 		RedirectType: "permanent",
 		RouteType:    "exact",
+		PrefixMode:   "preserve",
 	}
 
 	if len(extraParams) > 0 {
@@ -52,6 +54,9 @@ func NewRedirectRoute(redirectTo string, extraParams ...string) Route {
 	}
 	if len(extraParams) > 1 {
 		route.RedirectType = extraParams[1]
+	}
+	if len(extraParams) > 2 {
+		route.PrefixMode = extraParams[2]
 	}
 
 	return route

--- a/integration_tests/route_helpers.go
+++ b/integration_tests/route_helpers.go
@@ -26,29 +26,44 @@ type Route struct {
 	Disabled     bool   `bson:"disabled"`
 }
 
-func NewBackendRoute(backendID string) Route {
-	route := Route {
-		Handler: "backend",
+func NewBackendRoute(backendID string, extraParams ...string) Route {
+	route := Route{
+		Handler:   "backend",
 		BackendID: backendID,
 	}
 
-	return route
-}
-
-func NewRedirectRoute(redirectTo string) Route {
-	route := Route {
-		Handler: "redirect",
-		RedirectTo: redirectTo,
-		RedirectType: "permanent",
-		RouteType: "exact",
+	if len(extraParams) > 0 {
+		route.RouteType = extraParams[0]
 	}
 
 	return route
 }
 
-func NewGoneRoute() Route {
-	route := Route {
+func NewRedirectRoute(redirectTo string, extraParams ...string) Route {
+	route := Route{
+		Handler:      "redirect",
+		RedirectTo:   redirectTo,
+		RedirectType: "permanent",
+		RouteType:    "exact",
+	}
+
+	if len(extraParams) > 0 {
+		route.RouteType = extraParams[0]
+	}
+	if len(extraParams) > 1 {
+		route.RedirectType = extraParams[1]
+	}
+
+	return route
+}
+
+func NewGoneRoute(extraParams ...string) Route {
+	route := Route{
 		Handler: "gone",
+	}
+
+	if len(extraParams) > 0 {
+		route.RouteType = extraParams[0]
 	}
 
 	return route
@@ -65,39 +80,6 @@ func init() {
 func addBackend(id, url string) {
 	err := routerDB.C("backends").Insert(bson.M{"backend_id": id, "backend_url": url})
 	Expect(err).To(BeNil())
-}
-
-func addBackendRoute(path, backendID string, possibleRouteType ...string) {
-	route := NewBackendRoute(backendID)
-
-	if len(possibleRouteType) > 0 {
-		route.RouteType = possibleRouteType[0]
-	}
-
-	addRoute(path, route)
-}
-
-func addRedirectRoute(path, redirectTo string, extraParams ...string) {
-	route := NewRedirectRoute(redirectTo)
-
-	if len(extraParams) > 0 {
-		route.RouteType = extraParams[0]
-	}
-	if len(extraParams) > 1 {
-		route.RedirectType = extraParams[1]
-	}
-
-	addRoute(path, route)
-}
-
-func addGoneRoute(path string, possibleRouteType ...string) {
-	route := NewGoneRoute()
-
-	if len(possibleRouteType) > 0 {
-		route.RouteType = possibleRouteType[0]
-	}
-
-	addRoute(path, route)
 }
 
 func addRoute(path string, route Route) {

--- a/integration_tests/route_helpers.go
+++ b/integration_tests/route_helpers.go
@@ -23,7 +23,7 @@ type Route struct {
 	BackendID    string `bson:"backend_id"`
 	RedirectTo   string `bson:"redirect_to"`
 	RedirectType string `bson:"redirect_type"`
-	PrefixMode   string `bson:"prefix_mode"`
+	SegmentsMode string `bson:"segments_mode"`
 	Disabled     bool   `bson:"disabled"`
 }
 
@@ -46,7 +46,6 @@ func NewRedirectRoute(redirectTo string, extraParams ...string) Route {
 		RedirectTo:   redirectTo,
 		RedirectType: "permanent",
 		RouteType:    "exact",
-		PrefixMode:   "preserve",
 	}
 
 	if len(extraParams) > 0 {
@@ -56,7 +55,7 @@ func NewRedirectRoute(redirectTo string, extraParams ...string) Route {
 		route.RedirectType = extraParams[1]
 	}
 	if len(extraParams) > 2 {
-		route.PrefixMode = extraParams[2]
+		route.SegmentsMode = extraParams[2]
 	}
 
 	return route

--- a/integration_tests/route_loading_test.go
+++ b/integration_tests/route_loading_test.go
@@ -27,7 +27,7 @@ var _ = Describe("loading routes from the db", func() {
 	Context("a route with an unrecognised handler type", func() {
 		BeforeEach(func() {
 			addBackendRoute("/foo", "backend-1")
-			addRoute("/bar", map[string]interface{}{"handler": "fooey"})
+			addRoute("/bar", Route {Handler: "fooey"})
 			addBackendRoute("/baz", "backend-2")
 			reloadRoutes()
 		})

--- a/integration_tests/route_loading_test.go
+++ b/integration_tests/route_loading_test.go
@@ -26,9 +26,9 @@ var _ = Describe("loading routes from the db", func() {
 
 	Context("a route with an unrecognised handler type", func() {
 		BeforeEach(func() {
-			addBackendRoute("/foo", "backend-1")
-			addRoute("/bar", Route {Handler: "fooey"})
-			addBackendRoute("/baz", "backend-2")
+			addRoute("/foo", NewBackendRoute("backend-1"))
+			addRoute("/bar", Route{Handler: "fooey"})
+			addRoute("/baz", NewBackendRoute("backend-2"))
 			reloadRoutes()
 		})
 
@@ -48,10 +48,10 @@ var _ = Describe("loading routes from the db", func() {
 
 	Context("a route with a non-existent backend", func() {
 		BeforeEach(func() {
-			addBackendRoute("/foo", "backend-1")
-			addBackendRoute("/bar", "backend-non-existent")
-			addBackendRoute("/baz", "backend-2")
-			addBackendRoute("/qux", "backend-1")
+			addRoute("/foo", NewBackendRoute("backend-1"))
+			addRoute("/bar", NewBackendRoute("backend-non-existent"))
+			addRoute("/baz", NewBackendRoute("backend-2"))
+			addRoute("/qux", NewBackendRoute("backend-1"))
 			reloadRoutes()
 		})
 

--- a/integration_tests/route_selection_test.go
+++ b/integration_tests/route_selection_test.go
@@ -21,9 +21,9 @@ var _ = Describe("Route selection", func() {
 			backend2 = startSimpleBackend("backend 2")
 			addBackend("backend-1", backend1.URL)
 			addBackend("backend-2", backend2.URL)
-			addBackendRoute("/foo", "backend-1")
-			addBackendRoute("/bar", "backend-2")
-			addBackendRoute("/baz", "backend-1")
+			addRoute("/foo", NewBackendRoute("backend-1"))
+			addRoute("/bar", NewBackendRoute("backend-2"))
+			addRoute("/baz", NewBackendRoute("backend-1"))
 			reloadRoutes()
 		})
 		AfterEach(func() {
@@ -70,9 +70,9 @@ var _ = Describe("Route selection", func() {
 			backend2 = startSimpleBackend("backend 2")
 			addBackend("backend-1", backend1.URL)
 			addBackend("backend-2", backend2.URL)
-			addBackendRoute("/foo", "backend-1", "prefix")
-			addBackendRoute("/bar", "backend-2", "prefix")
-			addBackendRoute("/baz", "backend-1", "prefix")
+			addRoute("/foo", NewBackendRoute("backend-1", "prefix"))
+			addRoute("/bar", NewBackendRoute("backend-2", "prefix"))
+			addRoute("/baz", NewBackendRoute("backend-1", "prefix"))
 			reloadRoutes()
 		})
 		AfterEach(func() {
@@ -125,7 +125,7 @@ var _ = Describe("Route selection", func() {
 			inner = startSimpleBackend("inner")
 			addBackend("outer-backend", outer.URL)
 			addBackend("inner-backend", inner.URL)
-			addBackendRoute("/foo", "outer-backend", "prefix")
+			addRoute("/foo", NewBackendRoute("outer-backend", "prefix"))
 			reloadRoutes()
 		})
 		AfterEach(func() {
@@ -135,7 +135,7 @@ var _ = Describe("Route selection", func() {
 
 		Describe("with an exact child", func() {
 			BeforeEach(func() {
-				addBackendRoute("/foo/bar", "inner-backend")
+				addRoute("/foo/bar", NewBackendRoute("inner-backend"))
 				reloadRoutes()
 			})
 
@@ -157,7 +157,7 @@ var _ = Describe("Route selection", func() {
 
 		Describe("with a prefix child", func() {
 			BeforeEach(func() {
-				addBackendRoute("/foo/bar", "inner-backend", "prefix")
+				addRoute("/foo/bar", NewBackendRoute("inner-backend", "prefix"))
 				reloadRoutes()
 			})
 
@@ -192,8 +192,8 @@ var _ = Describe("Route selection", func() {
 			BeforeEach(func() {
 				innerer = startSimpleBackend("innerer")
 				addBackend("innerer-backend", innerer.URL)
-				addBackendRoute("/foo/bar", "inner-backend")
-				addBackendRoute("/foo/bar/baz", "innerer-backend", "prefix")
+				addRoute("/foo/bar", NewBackendRoute("inner-backend"))
+				addRoute("/foo/bar/baz", NewBackendRoute("innerer-backend", "prefix"))
 				reloadRoutes()
 			})
 			AfterEach(func() {
@@ -247,8 +247,8 @@ var _ = Describe("Route selection", func() {
 			backend2 = startSimpleBackend("backend 2")
 			addBackend("backend-1", backend1.URL)
 			addBackend("backend-2", backend2.URL)
-			addBackendRoute("/foo", "backend-1", "prefix")
-			addBackendRoute("/foo", "backend-2")
+			addRoute("/foo", NewBackendRoute("backend-1", "prefix"))
+			addRoute("/foo", NewBackendRoute("backend-2"))
 			reloadRoutes()
 		})
 		AfterEach(func() {
@@ -278,7 +278,7 @@ var _ = Describe("Route selection", func() {
 			other = startSimpleBackend("other backend")
 			addBackend("root", root.URL)
 			addBackend("other", other.URL)
-			addBackendRoute("/foo", "other")
+			addRoute("/foo", NewBackendRoute("other"))
 		})
 		AfterEach(func() {
 			root.Close()
@@ -286,7 +286,7 @@ var _ = Describe("Route selection", func() {
 		})
 
 		It("should handle an exact route at the root level", func() {
-			addBackendRoute("/", "root")
+			addRoute("/", NewBackendRoute("root"))
 			reloadRoutes()
 
 			resp := routerRequest("/")
@@ -300,7 +300,7 @@ var _ = Describe("Route selection", func() {
 		})
 
 		It("should handle a prefix route at the root level", func() {
-			addBackendRoute("/", "root", "prefix")
+			addRoute("/", NewBackendRoute("root", "prefix"))
 			reloadRoutes()
 
 			resp := routerRequest("/")
@@ -325,8 +325,8 @@ var _ = Describe("Route selection", func() {
 			recorder = startRecordingBackend()
 			addBackend("root", root.URL)
 			addBackend("other", recorder.URL())
-			addBackendRoute("/", "root", "prefix")
-			addBackendRoute("/foo/bar", "other", "prefix")
+			addRoute("/", NewBackendRoute("root", "prefix"))
+			addRoute("/foo/bar", NewBackendRoute("other", "prefix"))
 			reloadRoutes()
 		})
 		AfterEach(func() {
@@ -366,7 +366,7 @@ var _ = Describe("Route selection", func() {
 		})
 
 		It("should handle spaces (%20) in paths", func() {
-			addBackendRoute("/foo%20bar", "backend")
+			addRoute("/foo%20bar", NewBackendRoute("backend"))
 			reloadRoutes()
 
 			resp := routerRequest("/foo bar")

--- a/router.go
+++ b/router.go
@@ -194,9 +194,7 @@ func loadRoutes(c *mgo.Collection, mux *triemux.Mux, backends map[string]http.Ha
 				incomingURL.Path, prefix, route.BackendID))
 		case "redirect":
 			redirectTemporarily := (route.RedirectType == "temporary")
-			preserve := (route.SegmentsMode != "ignore" && prefix) ||
-				(route.SegmentsMode == "preserve" && !prefix)
-			handler := handlers.NewRedirectHandler(incomingURL.Path, route.RedirectTo, prefix, preserve, redirectTemporarily)
+			handler := handlers.NewRedirectHandler(incomingURL.Path, route.RedirectTo, shouldPreserveSegments(route), redirectTemporarily)
 			mux.Handle(incomingURL.Path, prefix, handler)
 			logDebug(fmt.Sprintf("router: registered %s (prefix: %v) -> %s",
 				incomingURL.Path, prefix, route.RedirectTo))
@@ -230,4 +228,18 @@ func (rt *Router) RouteStats() (stats map[string]interface{}) {
 	stats["count"] = mux.RouteCount()
 	stats["checksum"] = fmt.Sprintf("%x", mux.RouteChecksum())
 	return
+}
+
+func shouldPreserveSegments(route *Route) bool {
+	switch {
+	case route.RouteType == "exact" && route.SegmentsMode == "preserve":
+		return true
+	case route.RouteType == "exact":
+		return false
+	case route.RouteType == "prefix" && route.SegmentsMode == "ignore":
+		return false
+	case route.RouteType == "prefix":
+		return true
+	}
+	return false
 }

--- a/router.go
+++ b/router.go
@@ -37,6 +37,7 @@ type Route struct {
 	BackendID    string `bson:"backend_id"`
 	RedirectTo   string `bson:"redirect_to"`
 	RedirectType string `bson:"redirect_type"`
+	PrefixMode   string `bson:"prefix_mode"`
 	Disabled     bool   `bson:"disabled"`
 }
 
@@ -193,7 +194,8 @@ func loadRoutes(c *mgo.Collection, mux *triemux.Mux, backends map[string]http.Ha
 				incomingURL.Path, prefix, route.BackendID))
 		case "redirect":
 			redirectTemporarily := (route.RedirectType == "temporary")
-			handler := handlers.NewRedirectHandler(incomingURL.Path, route.RedirectTo, prefix, redirectTemporarily)
+			preserve := (route.PrefixMode != "ignore")
+			handler := handlers.NewRedirectHandler(incomingURL.Path, route.RedirectTo, prefix, preserve, redirectTemporarily)
 			mux.Handle(incomingURL.Path, prefix, handler)
 			logDebug(fmt.Sprintf("router: registered %s (prefix: %v) -> %s",
 				incomingURL.Path, prefix, route.RedirectTo))

--- a/router.go
+++ b/router.go
@@ -37,7 +37,7 @@ type Route struct {
 	BackendID    string `bson:"backend_id"`
 	RedirectTo   string `bson:"redirect_to"`
 	RedirectType string `bson:"redirect_type"`
-	PrefixMode   string `bson:"prefix_mode"`
+	SegmentsMode string `bson:"segments_mode"`
 	Disabled     bool   `bson:"disabled"`
 }
 
@@ -194,7 +194,8 @@ func loadRoutes(c *mgo.Collection, mux *triemux.Mux, backends map[string]http.Ha
 				incomingURL.Path, prefix, route.BackendID))
 		case "redirect":
 			redirectTemporarily := (route.RedirectType == "temporary")
-			preserve := (route.PrefixMode != "ignore")
+			preserve := (route.SegmentsMode != "ignore" && prefix) ||
+				(route.SegmentsMode == "preserve" && !prefix)
 			handler := handlers.NewRedirectHandler(incomingURL.Path, route.RedirectTo, prefix, preserve, redirectTemporarily)
 			mux.Handle(incomingURL.Path, prefix, handler)
 			logDebug(fmt.Sprintf("router: registered %s (prefix: %v) -> %s",


### PR DESCRIPTION
https://trello.com/c/BYS3dxxV/118-panopticon-unpublishings-should-redirect-without-keeping-subpath-medium

By default, prefix redirects preserve the path sections after the
prefix and add them to the redirect destination. This isn’t always the
desired behaviour.
This adds a new `prefix_mode` field for redirect routes, set to
`preserve` (the existing behaviour) or `ignore`. If the field isn’t
present in the route document, this will default to `preserve` for
prefix routes.
If the mode is set to `ignore`, the path sections after the prefix will
be discarded and all requests will be redirected to the exact target.

Includes test refactoring to support this work. See individual commits for details.

/cc @alext @bradwright 