### PR TITLE
Rate-limit route reloading

### DIFF
--- a/integration_tests/reload_api_test.go
+++ b/integration_tests/reload_api_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"crypto/sha1"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,6 +31,34 @@ var _ = Describe("reload API endpoint", func() {
 			resp := doRequest(newRequest("GET", routerAPIURL("/reload")))
 			Expect(resp.StatusCode).To(Equal(405))
 			Expect(resp.Header.Get("Allow")).To(Equal("POST"))
+		})
+
+		Context("with a non-zero reload interval", func() {
+			newRouterPort := 7999
+			newApiPort := 8000
+			BeforeEach(func() {
+				err := startRouter(newRouterPort, newApiPort, map[string]string{"ROUTER_RELOAD_INTERVAL": "100ms"})
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				stopRouter(newRouterPort)
+			})
+
+			It("should return 'already in progress' for requests within timeout", func() {
+				resp := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				resp2 := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				Expect(readBody(resp)).To(Equal("Reload triggered"))
+				Expect(readBody(resp2)).To(Equal("Reload already in progress"))
+			})
+
+			It("should return 'triggered' for requests after timeout", func() {
+				resp := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				time.Sleep(time.Second * 2)
+				resp2 := doRequest(newRequest("POST", routerURL("/reload", newApiPort)))
+				Expect(readBody(resp)).To(Equal("Reload triggered"))
+				Expect(readBody(resp2)).To(Equal("Reload triggered"))
+			})
 		})
 	})
 

--- a/integration_tests/reload_api_test.go
+++ b/integration_tests/reload_api_test.go
@@ -12,9 +12,9 @@ import (
 var _ = Describe("reload API endpoint", func() {
 
 	Describe("request handling", func() {
-		It("should return 200 for POST /reload", func() {
+		It("should return 202 for POST /reload", func() {
 			resp := doRequest(newRequest("POST", routerAPIURL("/reload")))
-			Expect(resp.StatusCode).To(Equal(200))
+			Expect(resp.StatusCode).To(Equal(202))
 		})
 
 		It("should return 404 for POST /foo", func() {

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -32,6 +32,9 @@ func reloadRoutes(optionalPort ...int) {
 	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/reload", port), "", nil)
 	Expect(err).To(BeNil())
 	Expect(resp.StatusCode).To(Equal(200))
+	// Now that reloading is done asynchronously, we need a small sleep to ensure
+	// it has actually been performed.
+	time.Sleep(time.Millisecond * 50)
 }
 
 var runningRouters = make(map[int]*exec.Cmd)
@@ -47,6 +50,7 @@ func startRouter(port, apiPort int, optionalExtraEnv ...envMap) error {
 	env["ROUTER_APIADDR"] = apiaddr
 	env["ROUTER_MONGO_DB"] = "router_test"
 	env["ROUTER_ERROR_LOG"] = tempLogfile.Name()
+	env["ROUTER_RELOAD_INTERVAL"] = "0s"
 	if len(optionalExtraEnv) > 0 {
 		for k, v := range optionalExtraEnv[0] {
 			env[k] = v

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -31,7 +31,7 @@ func reloadRoutes(optionalPort ...int) {
 	}
 	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/reload", port), "", nil)
 	Expect(err).To(BeNil())
-	Expect(resp.StatusCode).To(Equal(200))
+	Expect(resp.StatusCode).To(Equal(202))
 	// Now that reloading is done asynchronously, we need a small sleep to ensure
 	// it has actually been performed.
 	time.Sleep(time.Millisecond * 50)

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 	go catchListenAndServe(pubAddr, rout, "proxy", wg)
 	logInfo("router: listening for requests on " + pubAddr)
 
-	api, err := newAPIHandler(rout)
+	api, err := newAPIHandler(rout, reloadInterval)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/router_api.go
+++ b/router_api.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func newAPIHandler(rout *Router) (api http.Handler, err error) {
+func newAPIHandler(rout *Router, reloadInterval string) (api http.Handler, err error) {
 	reloadDuration, err := time.ParseDuration(reloadInterval)
 	if err != nil {
 		return nil, err

--- a/router_api.go
+++ b/router_api.go
@@ -36,6 +36,7 @@ func newAPIHandler(rout *Router) (api http.Handler, err error) {
 		select {
 		case reloadChan <- true:
 			logInfo("router: reload triggered")
+			w.WriteHeader(http.StatusAccepted)
 			w.Write([]byte("Reload triggered"))
 		default:
 			logInfo("router: reload already in progress")

--- a/router_api.go
+++ b/router_api.go
@@ -4,9 +4,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"runtime"
+	"time"
 )
 
-func newAPIHandler(rout *Router) http.Handler {
+func newAPIHandler(rout *Router) (api http.Handler, err error) {
+	reloadDuration, err := time.ParseDuration(reloadInterval)
+	if err != nil {
+		return nil, err
+	}
+	reloadChan := make(chan bool)
+	go func() {
+		// Rate-limit reloads to 1 per RELOAD_INTERVAL.
+		// This goroutine blocks until it receives a message on reloadChan, then
+		// waits for the timeout before calling reload.
+		for range reloadChan {
+			time.Sleep(reloadDuration)
+			rout.ReloadRoutes()
+		}
+	}()
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/reload", func(w http.ResponseWriter, r *http.Request) {
@@ -15,8 +31,16 @@ func newAPIHandler(rout *Router) http.Handler {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-
-		rout.ReloadRoutes()
+		// Send a message to the reload goroutine, which will start a new timeout
+		// before reloading, or do nothing if one is already in progress.
+		select {
+		case reloadChan <- true:
+			logInfo("router: reload triggered")
+			w.Write([]byte("Reload triggered"))
+		default:
+			logInfo("router: reload already in progress")
+			w.Write([]byte("Reload already in progress"))
+		}
 	})
 	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
@@ -65,5 +89,5 @@ func newAPIHandler(rout *Router) http.Handler {
 		w.Write([]byte("\n"))
 	})
 
-	return mux
+	return mux, nil
 }


### PR DESCRIPTION
Originally opened as #91 by @danielroseman 

> Although ReloadRoutes ensures that routes continue to be served while they are being reloaded, the reload itself still takes some time, and the client making the request will be blocked until the reload is complete. This means for example that content-store can become unresponsive when it tries to register a large number of routes.

> This change implements a rate limit, set by the ROUTER_RELOAD_INTERVAL env var (default 1s), so that a reload request waits for that interval before doing the actual reload, and any further requests within that time do not trigger an extra reload.

> Local testing shows that this speeds up the general time to register 900 content items by about 15%, but it's not possible in that environment to test how it affects the responsiveness of content-store in this scenario - that may need to be done in preview.

@alext commented previously:

> I'm a little unsure about whether this is the correct thing to be doing. It does change the behaviour of the reload endpoint so that it's no longer synchronous (at the least we should be returning a 202 status code now). At the moment, the router (and the router-api) have the nice property that when the reload call has returned, you know that the new routes are active.

> As an aside, I'm not sure that the delay is necessary here, it's simply the process of making it asynchronous that's helped the downstream apps. The router itself will happily continue to serve requests while it's reload endpoint is being hammered.

> It seems that the root of the problem is the fact the both write and read requests to the content-store share a pool of workers. That feels like a better place to approach solving this problem. It would be possible to implement a rate-limit for write requests in the publishing-api. That could ensure that at most a given number of write requests were active to the content-store, and therefore ensure that there were always some workers available to serve read requests.

We discussed this problem recently in relation to the performance of republishing thousands of documents from Whitehall. The speed improvement this will offer is essential in order to complete these republishing tasks in a timely manner.

Alex's comment against this change doesn't seem to be relevant now that publishing-api is no longer a dumb proxy for the content stores and is an app in its own right.

This has no user-facing performance impact, rather it removes what is essentially an artificial bottleneck on republishing.

I've rebased this on master and force pushed, and I've added a commit to make a POST to /reload return a 202 as Alex suggested.
