### PR TITLE
Make router reloading asynchronous

### DIFF
--- a/integration_tests/reload_api_test.go
+++ b/integration_tests/reload_api_test.go
@@ -11,9 +11,10 @@ import (
 var _ = Describe("reload API endpoint", func() {
 
 	Describe("request handling", func() {
-		It("should return 200 for POST /reload", func() {
+		It("should return 202 for POST /reload", func() {
 			resp := doRequest(newRequest("POST", routerAPIURL("/reload")))
-			Expect(resp.StatusCode).To(Equal(200))
+			Expect(resp.StatusCode).To(Equal(202))
+			Expect(readBody(resp)).To(Equal("Reload queued"))
 		})
 
 		It("should return 404 for POST /foo", func() {

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -31,7 +31,10 @@ func reloadRoutes(optionalPort ...int) {
 	}
 	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/reload", port), "", nil)
 	Expect(err).To(BeNil())
-	Expect(resp.StatusCode).To(Equal(200))
+	Expect(resp.StatusCode).To(Equal(202))
+	// Now that reloading is done asynchronously, we need a small sleep to ensure
+	// it has actually been performed.
+	time.Sleep(time.Millisecond * 50)
 }
 
 var runningRouters = make(map[int]*exec.Cmd)

--- a/main.go
+++ b/main.go
@@ -114,7 +114,10 @@ func main() {
 	go catchListenAndServe(pubAddr, rout, "proxy", wg)
 	logInfo("router: listening for requests on " + pubAddr)
 
-	api := newAPIHandler(rout)
+	api, err := newAPIHandler(rout)
+	if err != nil {
+		log.Fatal(err)
+	}
 	go catchListenAndServe(apiAddr, api, "api", wg)
 	logInfo("router: listening for refresh on " + apiAddr)
 


### PR DESCRIPTION
Supersedes #104 

Use a channel based mechanism for actioning router reload requests from
router-api. POST requests to /reload will now result in a message being
sent to a channel which will cause a goroutine to reload the routes.

The channel has a capacity of 1 in order to handle a request arriving
while routes are being reloaded. In this situation, the message will be
“queued” in the channel ready to be read again once the reload for loop
is complete.

The response for /reload is changed to be a 202 to reflect that the
reload is no longer synchronous.

Opinions are welcome on the test case.

- [ ] Deploy https://github.com/alphagov/router-api/pull/81 first