### PR TITLE
Fix command for installing godep in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project uses [Godep][godep] to manage it's dependencies.  If you have a
 working [Go][go] development setup, you should be able to install
 [Godep][godep] by running:
 
-    go install github.com/tools/godep
+    go get github.com/tools/godep
 
 [godep]: https://github.com/tools/godep
 [go]: http://golang.org


### PR DESCRIPTION
The readme file says to run `go install github.com/tools/godep` to install godep. However, running this in my development VM gave the following error message:

```
can't load package: package github.com/tools/godep: cannot find package "github.com/tools/godep" in any of:
	/usr/lib/goenv/versions/1.6.3/src/github.com/tools/godep (from $GOROOT)
	/var/govuk/gopath/src/github.com/tools/godep (from $GOPATH)
```

Looking at https://github.com/tools/godep/blob/master/Readme.md, the command it suggests is `go get github.com/tools/godep`, which works.

Is this simply a change in naming in newer versions of the `go` command, or am I missing something here?