### PR TITLE
Build process simplification and clarification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/.bundle/
-/gopath.tmp
-/router
+router
+__build

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 .PHONY: build run test clean
 
-BINARY := router
-SOURCE_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
-BUILDFILES := router.go main.go router_api.go version.go
+BINARY ?= $(PWD)/router
 
 ifdef RELEASE_VERSION
 VERSION := $(RELEASE_VERSION)
@@ -10,17 +8,17 @@ else
 VERSION := $(shell git describe --always | tr -d '\n'; test -z "`git status --porcelain`" || echo '-dirty')
 endif
 
-build: $(BINARY)
-
-run:
-	go run $(BUILDFILES)
-
-test: $(BINARY)
-	go test ./trie ./triemux
-	go test -v ./integration_tests
+all: clean build test
 
 clean:
 	rm -rf $(BINARY)
 
-$(BINARY): $(SOURCE_FILES)
-	go build -ldflags "-X main.version=$(VERSION)" -o $(BINARY) $(BUILDFILES)
+build:
+	go build -ldflags "-X main.version=$(VERSION)" -o $(BINARY)
+
+test: build
+	go test -race ./trie ./triemux
+	go test -race -v ./integration_tests
+
+run: build
+	$(BINARY)

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -43,7 +43,11 @@ func startRouter(port, apiPort int, optionalExtraEnv ...envMap) error {
 	pubaddr := fmt.Sprintf(":%d", port)
 	apiaddr := fmt.Sprintf(":%d", apiPort)
 
-	cmd := exec.Command("../router")
+	bin := os.Getenv("BINARY")
+	if bin == "" {
+		bin = "../router"
+	}
+	cmd := exec.Command(bin)
 
 	env := newEnvMap(os.Environ())
 	env["ROUTER_PUBADDR"] = pubaddr

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,17 +2,35 @@
 set -x
 set -eu
 
-REPO=alphagov/router
-export GOPATH=$PWD/gopath
-GO_GITHUB_PATH=$GOPATH/src/github.com
-BUILD_PATH=$GO_GITHUB_PATH/$REPO
+# The repository owner and name
+REPO="alphagov/router"
+# The name of the binary to output
+BINARY=$(basename "$REPO")
 
-rm -rf $GOPATH && mkdir -p $GOPATH/bin $BUILD_PATH
+# Define the Jenkins workspace root in case we're not running through Jenkins
+: ${WORKSPACE:=$PWD}
 
-rsync -a ./ $BUILD_PATH --exclude=gopath
+# Go projects need to be built from with a Go workspace, which is a directory
+# tree with a specific format.  The default checkout path isn't enough, so we
+# need to create that workspace and build from within there.  The GOPATH
+# envionment variable points to the location of the workspace.
+#
+# See https://golang.org/doc/code.html#Workspaces for more details.
+BUILD_DIR="__build"
+export GOPATH="$WORKSPACE/$BUILD_DIR"
 
-cd $BUILD_PATH && make
-cp ./router $WORKSPACE/router
+# Define the location within the GOPATH that the source should reside
+SRC_PATH="$GOPATH/src/github.com/$REPO"
 
-make test
-./router -version
+# Recreate the GOPATH workspace from scratch
+rm -rf "$GOPATH" && mkdir -p "$GOPATH/bin" "$SRC_PATH"
+
+# Copy the whole repo content into the build tree
+rsync -a ./ "$SRC_PATH" --exclude="$BUILD_DIR"
+
+# Move in to the source path, then build the binary into the Jenkins workspace
+# root (for later packaging) and run the tests
+(cd "$SRC_PATH" && BINARY="$WORKSPACE/$BINARY" make clean build test)
+
+# Output the version that was built
+"./$BINARY" -version


### PR DESCRIPTION
Part of standardising the build process for GOV.UK Go apps, this change simplifies the `Makefile`, and adds clarification to the `jenkins.sh` file as to what's going on.

Go projects need to be built from with a Go workspace, which is a directory tree with a specific format.  The default checkout path isn't enough, so we need to create that workspace and build from within there.  This functionality was already in the `jenkins.sh` file, but this changeset better documents what's going on and why for those folks who might not be aware.
