### PR TITLE
Add GOVUK_APP_NAME to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ADD . /go/src/github.com/alphagov/router
 
 RUN go install github.com/alphagov/router
 
+ENV GOVUK_APP_NAME router
 ENV ROUTER_PUBADDR :3054
 ENV ROUTER_APIADDR :3055
 ENV ROUTER_MONGO_URL mongo


### PR DESCRIPTION
I'm not sure if this is used in router, but all the other apps have one.