### PR TITLE
Push the built Go binary to S3, so we can deploy from AWS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node ('mongodb-2.4') {
   env.GOPATH    = "${WORKSPACE}/${BUILD_DIR}"
   env.SRC_PATH  = "${env.GOPATH}/src/github.com/${REPO}"
 
-    def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   try {
     stage("Checkout") {
@@ -59,6 +59,14 @@ node ('mongodb-2.4') {
     stage("Push release tag") {
       echo 'Pushing tag'
       govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+    }
+
+    // Push the Go binary for the build to S3, for AWS releases
+    if (env.BRANCH_NAME == "master") {
+      stage("Push binary to S3") {
+        target_tag = "release_${env.BUILD_NUMBER}"
+        govuk.uploadArtefactToS3('router', "s3://govuk-integration-artefact/router/${target_tag}/router")
+      }
     }
 
     if (govuk.hasDockerfile()) {


### PR DESCRIPTION
- In PR 128, changes similar to this were reverted because we didn't want to
  use new release tags without consulting with developers. We newly need these
  changes, as we're reverting from Router being deployed on AWS in a container,
  so use the old style release tags (hence why this isn't a simple revert of a
  revert).

https://trello.com/c/IbnMEmul/793-router-move-away-from-container-deployment