### PR TITLE
Tag a docker release image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,11 @@ node ('mongodb-2.4') {
       }
 
       if (env.BRANCH_NAME == "master") {
-        stage("Tag Docker image") {
+        stage("Tag Docker release image") {
+          govuk.pushDockerImage(repoName, env.BRANCH_NAME, "release")
+        }
+
+        stage("Tag Docker release_${env.BUILD_NUMBER} image") {
           dockerTag = "release_${env.BUILD_NUMBER}"
           govuk.pushDockerImage(repoName, env.BRANCH_NAME, dockerTag)
         }


### PR DESCRIPTION
Previously just a tag of "release_${buildNumber}" was being created and
not "release" which meant this was inconsistent with github and meant
that "release" can't be deployed on CI.