### PR TITLE
Update how the deploy job is run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,12 +55,6 @@ node ('mongodb-2.4') {
       archiveArtifacts 'router'
     }
 
-    // Update GitHub Status
-    stage("Push release tag") {
-      echo 'Pushing tag'
-      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
-    }
-
     // Push the Go binary for the build to S3, for AWS releases
     if (env.BRANCH_NAME == "master") {
       stage("Push binary to S3") {
@@ -92,6 +86,10 @@ node ('mongodb-2.4') {
     }
 
     if (env.BRANCH_NAME == "master") {
+      stage("Push release tag") {
+        govuk.pushTag('router', env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      }
+
       stage("Deploy to integration") {
         govuk.deployIntegration('router', env.BRANCH_NAME, "release_${env.BUILD_NUMBER}", 'deploy')
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,11 +91,11 @@ node ('mongodb-2.4') {
       }
     }
 
-    // Deploy application
-    stage("Deploy") {
-      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+    if (env.BRANCH_NAME == "master") {
+      stage("Deploy to integration") {
+        govuk.deployIntegration('router', env.BRANCH_NAME, "release_${env.BUILD_NUMBER}", 'deploy')
+      }
     }
-
   } catch (e) {
       currentBuild.result = "FAILED"
       step([$class: 'Mailer',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,13 @@ node ('mongodb-2.4') {
         govuk.pushTag('router', env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
       }
 
+      stage("Push to Gitlab") {
+        try {
+          govuk.pushToMirror('router', env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+        } catch (e) {
+        }
+      }
+
       stage("Deploy to integration") {
         govuk.deployIntegration('router', env.BRANCH_NAME, "release_${env.BUILD_NUMBER}", 'deploy')
       }


### PR DESCRIPTION
Use the govuk_jenkinslib deployIntegration function, and switch to
deploying release_... instead of release, as this means it's
possible to more easily work out what was released. The Release app
also depends on the tag being used, rather than the branch for
displaying releases against commits.