### PR TITLE
Run publishing-e2e-tests when Router builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,10 @@ node ('mongodb-2.4') {
       }
     }
 
+    stage("Run publishing end-to-end tests") {
+      govuk.runPublishingE2ETests("ROUTER_COMMITISH", "test-against", "router")
+    }
+
     // Archive Binaries from build
     stage("Archive Artifact") {
       archiveArtifacts 'router'


### PR DESCRIPTION
This will trigger a dependent build on [publishing-e2e-tests][1] when
builds are done for Router. This is because we want changes to router to
be tested amongst the context of publishing-e2e-tests since a change in
router behaviour can break these apps.

[1]: https://github.com/alphagov/publishing-e2e-tests