### PR TITLE
Log errors to sentry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,11 +61,13 @@ node ('mongodb-2.4') {
     }
 
     // Push the Go binary for the build to S3, for AWS releases
-    if (env.BRANCH_NAME == "master") {
-      stage("Push binary to S3") {
+    stage("Push binary to S3") {
+      if (env.BRANCH_NAME == "master") {
         govuk.uploadArtefactToS3('router', "s3://govuk-integration-artefact/router/release/router")
         target_tag = "release_${env.BUILD_NUMBER}"
         govuk.uploadArtefactToS3('router', "s3://govuk-integration-artefact/router/${target_tag}/router")
+      } else {
+        govuk.uploadArtefactToS3('router', "s3://govuk-integration-artefact/router/${env.BRANCH_NAME}/router")
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ The `backends` collection uses the following data structure:
 }
 ```
 
+Error logging
+-------------
+
+The logger package stores errors in logfiles and reports them to Sentry.
+
 License
 -------
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/alext/tablecloth v0.0.0-20150502092832-fbddb1a44a21
+	github.com/getsentry/sentry-go v0.2.1 // indirect
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/golang/protobuf v0.0.0-20160712193813-874264fbbb43 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/alext/tablecloth v0.0.0-20150502092832-fbddb1a44a21
-	github.com/getsentry/sentry-go v0.2.1 // indirect
+	github.com/getsentry/sentry-go v0.2.1
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/golang/protobuf v0.0.0-20160712193813-874264fbbb43 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
 github.com/alext/tablecloth v0.0.0-20150502092832-fbddb1a44a21 h1:oNDnuu3fHqcUrClLyfdUmugXioJorjZnCZkB5Hh3NQs=
 github.com/alext/tablecloth v0.0.0-20150502092832-fbddb1a44a21/go.mod h1:jKjUrWeqND77iVx9JTIHBPwsFrcvHWg0+LinaAH6NXM=
+github.com/getsentry/sentry-go v0.2.1 h1:zCyr8wS1NQM7ixbWNh8lBRMlQZSM3aMXQCqXgCDwI44=
+github.com/getsentry/sentry-go v0.2.1/go.mod h1:2QfSdvxz4IZGyB5izm1TtADFhlhfj1Dcesrg8+A/T9Y=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/golang/protobuf v0.0.0-20160712193813-874264fbbb43 h1:hqD5LoecFbk/F8KRMF5THTQDx6HLNdfCcth8BDpy6JQ=
 github.com/golang/protobuf v0.0.0-20160712193813-874264fbbb43/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -13,6 +16,8 @@ github.com/onsi/ginkgo v0.0.0-20160716051733-7d3240191d7b h1:tQgOdRdXLi5UmMEBGnz
 github.com/onsi/ginkgo v0.0.0-20160716051733-7d3240191d7b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20160713044445-9574b2d94c03 h1:0KuWmiYjZpQkXeyUgpH7dbSCPdNxZQOpsUuMNaYC0E8=
 github.com/onsi/gomega v0.0.0-20160713044445-9574b2d94c03/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/pingcap/errors v0.11.1/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 h1:7z3LSn867ex6VSaahyKadf4WtSsJIgne6A1WLOAGM8A=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
 github.com/tsenart/vegeta v0.0.0-20160525192120-dbb7ee1d3e54 h1:cAbFLD597fDhkRdQSZJE1wWvC/E2FpWE8lzYxhwrt00=

--- a/handlers/backend_handler.go
+++ b/handlers/backend_handler.go
@@ -82,6 +82,7 @@ func (bt *backendTransport) RoundTrip(req *http.Request) (resp *http.Response, e
 		// Log the error (deferred to allow special case error handling to add/change details)
 		logDetails := map[string]interface{}{"error": err.Error(), "status": 500}
 		defer bt.logger.LogFromBackendRequest(logDetails, req)
+		defer logger.NotifySentry(logger.ReportableError{ Error: err, Request: req, Response: resp })
 
 		// Intercept some specific errors and generate an appropriate HTTP error response
 		if netErr, ok := err.(net.Error); ok {

--- a/logger/sentry.go
+++ b/logger/sentry.go
@@ -1,0 +1,48 @@
+package logger
+
+import (
+  "log"
+  "time"
+  "net/http"
+
+  sentry "github.com/getsentry/sentry-go"
+)
+
+type RecoveredError struct {
+  ErrorMessage string
+}
+
+func (re RecoveredError) Error() string {
+  return re.ErrorMessage
+}
+
+type ReportableError struct {
+  Error    error
+  Request  *http.Request
+  Response *http.Response
+}
+
+func (re ReportableError) hint() *sentry.EventHint {
+  return &sentry.EventHint{
+    Request:  re.Request,
+    Response: re.Response,
+  }
+}
+
+func (re ReportableError) scope() *sentry.Scope {
+  return &sentry.Scope{}
+}
+
+func NotifySentry(re ReportableError) {
+  // We don't need to set SENTRY_ENVIRONMENT, SENTRY_DSN or SENTRY_RELEASE
+  // in ClientOptions as they are automatically picked up as env vars.
+  // https://docs.sentry.io/platforms/go/config/
+  client, err := sentry.NewClient(sentry.ClientOptions{})
+  if err != nil {
+    log.Printf("router: Sentry initialization failed: %v\n", err)
+    return
+  }
+
+  client.CaptureException(re.Error, re.hint(), re.scope())
+  client.Flush(time.Second * 5)
+}

--- a/vendor/github.com/getsentry/sentry-go/.craft.yml
+++ b/vendor/github.com/getsentry/sentry-go/.craft.yml
@@ -1,0 +1,12 @@
+github:
+  owner: getsentry
+  repo: sentry-go
+preReleaseCommand: bash scripts/craft-pre-release.sh
+changelogPolicy: simple
+targets:
+  - name: github
+    tagPrefix: v
+  - name: registry
+    type: sdk
+    config:
+      canonical: "github:getsentry/sentry-go"

--- a/vendor/github.com/getsentry/sentry-go/.gitignore
+++ b/vendor/github.com/getsentry/sentry-go/.gitignore
@@ -1,0 +1,6 @@
+coverage.txt
+
+# Just my personal way of tracking stuff — Kamil
+FIXME.md
+TODO.md
+!NOTES.md

--- a/vendor/github.com/getsentry/sentry-go/.golangci.yml
+++ b/vendor/github.com/getsentry/sentry-go/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  enable-all: true
+  disable:
+    - megacheck
+    - stylecheck
+run:
+  skip-dirs:
+    - echo
+    - example/echo

--- a/vendor/github.com/getsentry/sentry-go/.travis.yml
+++ b/vendor/github.com/getsentry/sentry-go/.travis.yml
@@ -1,0 +1,28 @@
+sudo: false
+
+language: go
+go:
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+
+env:
+  - GO111MODULE=on
+
+before_install:
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+
+script:
+  - golangci-lint run
+  - go build
+  - go test
+
+notifications:
+  webhooks:
+    urls:
+      - https://zeus.ci/hooks/befe9810-9285-11e9-b01a-0a580a281808/public/provider/travis/webhook
+    on_success: always
+    on_failure: always
+    on_start: always
+    on_cancel: always
+    on_error: always

--- a/vendor/github.com/getsentry/sentry-go/CHANGELOG.md
+++ b/vendor/github.com/getsentry/sentry-go/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+## v0.1.3
+
+- feat: Move frames context reading into `contextifyFramesIntegration` (#28)
+
+_NOTE:_
+In case of any performance isues due to source contexts IO, you can let us know and turn off the integration in the meantime with:
+
+```go
+sentry.Init(sentry.ClientOptions{
+	Integrations: func(integrations []sentry.Integration) []sentry.Integration {
+		var filteredIntegrations []sentry.Integration
+		for _, integration := range integrations {
+			if integration.Name() == "ContextifyFrames" {
+				continue
+			}
+			filteredIntegrations = append(filteredIntegrations, integration)
+		}
+		return filteredIntegrations
+	},
+})
+```
+
+## v0.1.2
+
+- feat: Better source code location resolution and more useful inapp frames (#26)
+- feat: Use `noopTransport` when no `Dsn` provided (#27)
+- ref: Allow empty `Dsn` instead of returning an error (#22)
+- fix: Use `NewScope` instead of literal struct inside a `scope.Clear` call (#24)
+- fix: Add to `WaitGroup` before the request is put inside a buffer (#25)
+
+## v0.1.1
+
+- fix: Check for initialized `Client` in `AddBreadcrumbs` (#20)
+- build: Bump version when releasing with Craft (#19)
+
+## v0.1.0
+
+- First stable release! \o/
+
+## v0.0.1-beta.5
+
+- feat: **[breaking]** Add `NewHTTPTransport` and `NewHTTPSyncTransport` which accepts all transport options
+- feat: New `HTTPSyncTransport` that blocks after each call
+- feat: New `Echo` integration
+- ref: **[breaking]** Remove `BufferSize` option from `ClientOptions` and move it to `HTTPTransport` instead
+- ref: Export default `HTTPTransport`
+- ref: Export `net/http` integration handler
+- ref: Set `Request` instantly in the package handlers, not in `recoverWithSentry` so it can be accessed later on
+- ci: Add craft config
+
+## v0.0.1-beta.4
+
+- feat: `IgnoreErrors` client option and corresponding integration
+- ref: Reworked `net/http` integration, wrote better example and complete readme
+- ref: Reworked `Gin` integration, wrote better example and complete readme
+- ref: Reworked `Iris` integration, wrote better example and complete readme
+- ref: Reworked `Negroni` integration, wrote better example and complete readme
+- ref: Reworked `Martini` integration, wrote better example and complete readme
+- ref: Remove `Handle()` from frameworks handlers and return it directly from New
+
+## v0.0.1-beta.3
+
+- feat: `Iris` framework support with `sentryiris` package
+- feat: `Gin` framework support with `sentrygin` package
+- feat: `Martini` framework support with `sentrymartini` package
+- feat: `Negroni` framework support with `sentrynegroni` package
+- feat: Add `Hub.Clone()` for easier frameworks integration
+- feat: Return `EventID` from `Recovery` methods
+- feat: Add `NewScope` and `NewEvent` functions and use them in the whole codebase
+- feat: Add `AddEventProcessor` to the `Client`
+- fix: Operate on requests body copy instead of the original
+- ref: Try to read source files from the root directory, based on the filename as well, to make it work on AWS Lambda
+- ref: Remove `gocertifi` dependence and document how to provide your own certificates
+- ref: **[breaking]** Remove `Decorate` and `DecorateFunc` methods in favor of `sentryhttp` package
+- ref: **[breaking]** Allow for integrations to live on the client, by passing client instance in `SetupOnce` method
+- ref: **[breaking]** Remove `GetIntegration` from the `Hub`
+- ref: **[breaking]** Remove `GlobalEventProcessors` getter from the public API
+
+## v0.0.1-beta.2
+
+- feat: Add `AttachStacktrace` client option to include stacktrace for messages
+- feat: Add `BufferSize` client option to configure transport buffer size
+- feat: Add `SetRequest` method on a `Scope` to control `Request` context data
+- feat: Add `FromHTTPRequest` for `Request` type for easier extraction
+- ref: Extract `Request` information more accurately
+- fix: Attach `ServerName`, `Release`, `Dist`, `Environment` options to the event
+- fix: Don't log events dropped due to full transport buffer as sent
+- fix: Don't panic and create an appropriate event when called `CaptureException` or `Recover` with `nil` value
+
+## v0.0.1-beta
+
+- Initial release

--- a/vendor/github.com/getsentry/sentry-go/CONTRIBUTION.md
+++ b/vendor/github.com/getsentry/sentry-go/CONTRIBUTION.md
@@ -1,0 +1,41 @@
+## Testing
+
+```bash
+$ go test
+```
+
+### Watch mode
+
+Use: https://github.com/cespare/reflex
+
+```bash
+$ reflex -g '*.go' -d "none" -- sh -c 'printf "\n"; go test'
+```
+
+### With data race detection
+
+```bash
+$ go test -race
+```
+
+### Coverage
+```bash
+$ go test -race -coverprofile=coverage.txt -covermode=atomic && go tool cover -html coverage.txt
+```
+
+## Linting
+
+```bash
+$ golangci-lint run
+```
+
+## Release
+
+1. Update changelog with new version in `vX.X.X` format title and list of changes
+2. Commit with `misc: vX.X.X changelog` commit message and push to `master`
+3. Let `craft` do the rest
+
+```bash
+$ craft prepare X.X.X
+$ craft publish X.X.X --skip-status-check
+```

--- a/vendor/github.com/getsentry/sentry-go/LICENSE
+++ b/vendor/github.com/getsentry/sentry-go/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/getsentry/sentry-go/MIGRATION.md
+++ b/vendor/github.com/getsentry/sentry-go/MIGRATION.md
@@ -1,0 +1,392 @@
+# `raven-go` to `sentry-go` Migration Guide
+
+## Installation
+
+raven-go
+
+```go
+go get github.com/getsentry/raven-go
+```
+
+sentry-go
+
+```go
+go get github.com/getsentry/sentry-go@v0.0.1
+```
+
+## Configuration
+
+raven-go
+
+```go
+import "github.com/getsentry/raven-go"
+
+func main() {
+    raven.SetDSN("https://16427b2f210046b585ee51fd8a1ac54f@sentry.io/1")
+}
+```
+
+sentry-go
+
+```go
+import (
+    "fmt"
+    "github.com/getsentry/sentry-go"
+)
+
+func main() {
+    err := sentry.Init(sentry.ClientOptions{
+        Dsn: "https://16427b2f210046b585ee51fd8a1ac54f@sentry.io/1",
+    })
+
+    if err != nil {
+        fmt.Printf("Sentry initialization failed: %v\n", err)
+    }
+}
+```
+
+raven-go
+
+```go
+SetDSN()
+SetDefaultLoggerName()
+SetDebug()
+SetEnvironment()
+SetRelease()
+SetSampleRate()
+SetIgnoreErrors()
+SetIncludePaths()
+```
+
+sentry-go
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "https://16427b2f210046b585ee51fd8a1ac54f@sentry.io/1",
+    DebugWriter: os.Stderr,
+    Debug: true,
+    Environment: "environment",
+    Release: "release",
+    SampleRate: 0.5,
+    // IgnoreErrors: TBD,
+    // IncludePaths: TBD
+})
+```
+
+Available options: see [Configuration](https://docs.sentry.io/platforms/go/config/) section.
+
+### Providing SSL Certificates
+
+By default, TLS uses the host's root CA set. If you don't have `ca-certificates` (which should be your go-to way of fixing the issue of missing ceritificates) and want to use `gocertifi` instead, you can provide pre-loaded cert files as one of the options to the `sentry.Init` call:
+
+```go
+package main
+
+import (
+    "log"
+
+    "github.com/certifi/gocertifi"
+    "github.com/getsentry/sentry-go"
+)
+
+sentryClientOptions := sentry.ClientOptions{
+    Dsn: "https://16427b2f210046b585ee51fd8a1ac54f@sentry.io/1",
+}
+
+rootCAs, err := gocertifi.CACerts()
+if err != nil {
+    log.Println("Coudnt load CA Certificates: %v\n", err)
+} else {
+    sentryClientOptions.CaCerts = rootCAs
+}
+
+sentry.Init(sentryClientOptions)
+```
+
+## Usage
+
+### Capturing Errors
+
+raven-go
+
+```go
+f, err := os.Open("filename.ext")
+if err != nil {
+    raven.CaptureError(err, nil)
+}
+```
+
+sentry-go
+
+```go
+f, err := os.Open("filename.ext")
+if err != nil {
+    sentry.CaptureException(err)
+}
+```
+
+### Capturing Panics
+
+raven-go
+
+```go
+raven.CapturePanic(func() {
+    // do all of the scary things here
+}, nil)
+```
+
+sentry-go
+
+```go
+func() {
+    defer sentry.Recover()
+    // do all of the scary things here
+}()
+```
+
+### Capturing Messages
+
+raven-go
+
+```go
+raven.CaptureMessage("Something bad happened and I would like to know about that")
+```
+
+sentry-go
+
+```go
+sentry.CaptureMessage("Something bad happened and I would like to know about that")
+```
+
+### Capturing Events
+
+raven-go
+
+```go
+packet := &raven.Packet{
+    Message: "Hand-crafted event",
+    Extra: &raven.Extra{
+        "runtime.Version": runtime.Version(),
+        "runtime.NumCPU": runtime.NumCPU(),
+    },
+}
+raven.Capture(packet)
+```
+
+sentry-go
+
+```go
+event := &sentry.NewEvent()
+event.Message = "Hand-crafted event"
+event.Extra["runtime.Version"] = runtime.Version()
+event.Extra["runtime.NumCPU"] = runtime.NumCPU()
+
+sentry.CaptureEvent(event)
+```
+
+### Additional Data
+
+See Context section.
+
+### Event Sampling
+
+raven-go
+
+```go
+raven.SetSampleRate(0.25)
+```
+
+sentry-go
+
+```go
+sentry.Init(sentry.ClientOptions{
+    SampleRate: 0.25,
+})
+```
+
+### Awaiting the response (not recommended)
+
+```go
+raven.CaptureMessageAndWait("Something bad happened and I would like to know about that")
+```
+
+sentry-go
+
+```go
+sentry.CaptureMessage("Something bad happened and I would like to know about that")
+
+if sentry.Flush(time.Second * 2) {
+    // event delivered
+} else {
+    // timeout reached
+}
+```
+
+## Context
+
+### Per-event
+
+raven-go
+
+```go
+raven.CaptureError(err, map[string]string{"browser": "Firefox"}, &raven.Http{
+    Method: "GET",
+    URL: "https://example.com/raven-go"
+})
+```
+
+sentry-go
+
+```go
+sentry.WithScope(func(scope *sentry.Scope) {
+    scope.SetTag("browser", "Firefox")
+    scope.SetContext("Request", map[string]string{
+        "Method": "GET",
+        "URL": "https://example.com/raven-go",
+    })
+    sentry.CaptureException(err)
+})
+```
+
+### Globally
+
+#### SetHttpContext
+
+raven-go
+
+```go
+raven.SetHttpContext(&raven.Http{
+    Method: "GET",
+    URL: "https://example.com/raven-go",
+})
+```
+
+sentry-go
+
+```go
+sentry.ConfigureScope(func(scope *sentry.Scope) {
+    scope.SetContext("Request", map[string]string{
+        "Method": "GET",
+        "URL": "https://example.com/raven-go",
+    })
+})
+```
+
+#### SetTagsContext
+
+raven-go
+
+```go
+t := map[string]string{"day": "Friday", "sport": "Weightlifting"}
+raven.SetTagsContext(map[string]string{"day": "Friday", "sport": "Weightlifting"})
+```
+
+sentry-go
+
+```go
+sentry.ConfigureScope(func(scope *sentry.Scope) {
+    scope.SetTags(map[string]string{"day": "Friday", "sport": "Weightlifting"})
+})
+```
+
+#### SetUserContext
+
+raven-go
+
+```go
+raven.SetUserContext(&raven.User{
+    ID: "1337",
+    Username: "kamilogorek",
+    Email: "kamil@sentry.io",
+    IP: "127.0.0.1",
+})
+```
+
+sentry-go
+
+```go
+sentry.ConfigureScope(func(scope *sentry.Scope) {
+    scope.SetUser(sentry.User{
+        ID: "1337",
+        Username: "kamilogorek",
+        Email: "kamil@sentry.io",
+        IPAddress: "127.0.0.1",
+    })
+})
+```
+
+#### ClearContext
+
+raven-go
+
+```go
+raven.ClearContext()
+```
+
+sentry-go
+
+```go
+sentry.ConfigureScope(func(scope *sentry.Scope) {
+    scope.Clear()
+})
+```
+
+#### WrapWithExtra
+
+raven-go
+
+```go
+path := "filename.ext"
+f, err := os.Open(path)
+if err != nil {
+    err = raven.WrapWithExtra(err, map[string]string{"path": path, "cwd": os.Getwd()}
+    raven.CaptureError(err, nil)
+}
+```
+
+sentry-go
+
+```go
+// use `sentry.WithScope`, see "Context / Per-event Section"
+path := "filename.ext"
+f, err := os.Open(path)
+if err != nil {
+    sentry.WithScope(func(scope *sentry.Scope) {
+        sentry.SetExtras(map[string]interface{}{"path": path, "cwd": os.Getwd())
+        sentry.CaptureException(err)
+    })
+}
+```
+
+## Integrations
+
+### net/http
+
+raven-go
+
+```go
+mux := http.NewServeMux
+http.Handle("/", raven.Recoverer(mux))
+
+// or
+
+func root(w http.ResponseWriter, r *http.Request) {}
+http.HandleFunc("/", raven.RecoveryHandler(root))
+```
+
+sentry-go
+
+```go
+sentryHandler := sentryhttp.New(sentryhttp.Options{
+    Repanic: false,
+    WaitForDelivery: true,
+})
+
+mux := http.NewServeMux
+http.Handle("/", sentryHandler.Handle(mux))
+
+// or
+
+func root(w http.ResponseWriter, r *http.Request) {}
+http.HandleFunc("/", sentryHandler.HandleFunc(root))
+```

--- a/vendor/github.com/getsentry/sentry-go/README.md
+++ b/vendor/github.com/getsentry/sentry-go/README.md
@@ -1,0 +1,107 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry SDK for Go
+
+[![Build Status](https://travis-ci.com/getsentry/sentry-go.svg?branch=master)](https://travis-ci.com/getsentry/sentry-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/getsentry/sentry-go)](https://goreportcard.com/report/github.com/getsentry/sentry-go)
+
+`sentry-go` provides a Sentry client implementation for the Go programming language. This is the next line of the Go SDK for [Sentry](https://sentry.io/), intended to replace the `raven-go` package.
+
+> Looking for the old `raven-go` SDK documentation? See the Legacy client section [here](https://docs.sentry.io/clients/go/).
+> If you want to start using sentry-go instead, check out the [migration guide](https://docs.sentry.io/platforms/go/migration/).
+
+## Requirements
+
+We verify this package against N-2 recent versions of Go compiler. As of June 2019, those versions are:
+
+* 1.10
+* 1.11
+* 1.12
+
+## Installation
+
+`sentry-go` can be installed like any other Go library through `go get`:
+
+```bash
+$ go get github.com/getsentry/sentry-go
+```
+
+Or, if you are already using Go Modules, specify a version number as well:
+
+```bash
+$ go get github.com/getsentry/sentry-go@v0.1.0
+```
+
+## Configuration
+
+To use `sentry-go`, you’ll need to import the `sentry-go` package and initialize it with the client options that will include your DSN. If you specify the `SENTRY_DSN` environment variable, you can omit this value from options and it will be picked up automatically for you. The release and environment can also be specified in the environment variables `SENTRY_RELEASE` and `SENTRY_ENVIRONMENT` respectively.
+
+More on this in [Configuration](https://docs.sentry.io/platforms/go/config/) section.
+
+## Usage
+
+By default, Sentry Go SDK uses asynchronous transport, which in the code example below requires an explicit awaiting for event delivery to be finished using `sentry.Flush` method. It is necessary, because otherwise the program would not wait for the async HTTP calls to return a response, and exit the process immediately when it reached the end of the `main` function. It would not be required inside a running goroutine or if you would use `HTTPSyncTransport`, which you can read about in `Transports` section.
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+    "time"
+
+    "github.com/getsentry/sentry-go"
+)
+
+func main() {
+  err := sentry.Init(sentry.ClientOptions{
+    Dsn: "___DSN___",
+  })
+
+  if err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+  }
+  
+  f, err := os.Open("filename.ext")
+  if err != nil {
+    sentry.CaptureException(err)
+    sentry.Flush(time.Second * 5)
+  }
+}
+```
+
+For more detailed information about how to get the most out of `sentry-go` there is additional documentation available:
+
+- [Configuration](https://docs.sentry.io/platforms/go/config)
+- [Error Reporting](https://docs.sentry.io/error-reporting/quickstart?platform=go)
+- [Enriching Error Data](https://docs.sentry.io/enriching-error-data/context?platform=go)
+- [Transports](https://docs.sentry.io/platforms/go/transports)
+- [Integrations](https://docs.sentry.io/platforms/go/integrations)
+  - [net/http](https://docs.sentry.io/platforms/go/http)
+  - [echo](https://docs.sentry.io/platforms/go/echo)
+  - [gin](https://docs.sentry.io/platforms/go/gin)
+  - [iris](https://docs.sentry.io/platforms/go/iris)
+  - [martini](https://docs.sentry.io/platforms/go/martini)
+  - [negroni](https://docs.sentry.io/platforms/go/negroni)
+
+## Resources:
+
+- [Bug Tracker](https://github.com/getsentry/sentry-go/issues)
+- [GitHub Project](https://github.com/getsentry/sentry-go)
+- [Godocs](https://godoc.org/github.com/getsentry/sentry-go)
+- [@getsentry](https://twitter.com/getsentry) on Twitter for updates
+
+## License
+
+Licensed under the BSD license, see `LICENSE`
+
+## Community
+
+Want to join our Sentry's `community-golang` channel, get involved and help us improve the SDK?
+
+Do not hesistate to shoot me up an email at [kamil@sentry.io](mailto:kamil@sentry.io) for Slack invite!

--- a/vendor/github.com/getsentry/sentry-go/client.go
+++ b/vendor/github.com/getsentry/sentry-go/client.go
@@ -1,0 +1,429 @@
+package sentry
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"reflect"
+	"sort"
+	"time"
+)
+
+// Logger is an instance of log.Logger that is use to provide debug information about running Sentry Client
+// can be enabled by either using `Logger.SetOutput` directly or with `Debug` client option
+var Logger = log.New(ioutil.Discard, "[Sentry] ", log.LstdFlags) // nolint: gochecknoglobals
+
+type EventProcessor func(event *Event, hint *EventHint) *Event
+
+type EventModifier interface {
+	ApplyToEvent(event *Event, hint *EventHint) *Event
+}
+
+var globalEventProcessors []EventProcessor // nolint: gochecknoglobals
+
+func AddGlobalEventProcessor(processor EventProcessor) {
+	globalEventProcessors = append(globalEventProcessors, processor)
+}
+
+// Integration allows for registering a functions that modify or discard captured events.
+type Integration interface {
+	Name() string
+	SetupOnce(client *Client)
+}
+
+// ClientOptions that configures a SDK Client
+type ClientOptions struct {
+	// The DSN to use. If the DSN is not set, the client is effectively disabled.
+	Dsn string
+	// In debug mode, the debug information is printed to stdout to help you understand what
+	// sentry is doing.
+	Debug bool
+	// Configures whether SDK should generate and attach stacktraces to pure capture message calls.
+	AttachStacktrace bool
+	// The sample rate for event submission (0.0 - 1.0, defaults to 1.0).
+	SampleRate float32
+	// List of regexp strings that will be used to match against event's message
+	// and if applicable, caught errors type and value.
+	// If the match is found, then a whole event will be dropped.
+	IgnoreErrors []string
+	// Before send callback.
+	BeforeSend func(event *Event, hint *EventHint) *Event
+	// Before breadcrumb add callback.
+	BeforeBreadcrumb func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb
+	// Integrations to be installed on the current Client, receives default integrations
+	Integrations func([]Integration) []Integration
+	// io.Writer implementation that should be used with the `Debug` mode
+	DebugWriter io.Writer
+	// The transport to use.
+	// This is an instance of a struct implementing `Transport` interface.
+	// Defaults to `httpTransport` from `transport.go`
+	Transport Transport
+	// The server name to be reported.
+	ServerName string
+	// The release to be sent with events.
+	Release string
+	// The dist to be sent with events.
+	Dist string
+	// The environment to be sent with events.
+	Environment string
+	// Maximum number of breadcrumbs.
+	MaxBreadcrumbs int
+	// An optional pointer to `http.Transport` that will be used with a default HTTPTransport.
+	HTTPTransport *http.Transport
+	// An optional HTTP proxy to use.
+	// This will default to the `http_proxy` environment variable.
+	// or `https_proxy` if that one exists.
+	HTTPProxy string
+	// An optional HTTPS proxy to use.
+	// This will default to the `HTTPS_PROXY` environment variable
+	// or `http_proxy` if that one exists.
+	HTTPSProxy string
+	// An optionsl CaCerts to use.
+	// Defaults to `gocertifi.CACerts()`.
+	CaCerts *x509.CertPool
+}
+
+// Client is the underlying processor that's used by the main API and `Hub` instances.
+type Client struct {
+	options         ClientOptions
+	dsn             *Dsn
+	eventProcessors []EventProcessor
+	integrations    []Integration
+	Transport       Transport
+}
+
+// NewClient creates and returns an instance of `Client` configured using `ClientOptions`.
+func NewClient(options ClientOptions) (*Client, error) {
+	if options.Debug {
+		debugWriter := options.DebugWriter
+		if debugWriter == nil {
+			debugWriter = os.Stdout
+		}
+		Logger.SetOutput(debugWriter)
+	}
+
+	if options.Dsn == "" {
+		options.Dsn = os.Getenv("SENTRY_DSN")
+	}
+
+	if options.Release == "" {
+		options.Release = os.Getenv("SENTRY_RELEASE")
+	}
+
+	if options.Environment == "" {
+		options.Environment = os.Getenv("SENTRY_ENVIRONMENT")
+	}
+
+	var dsn *Dsn
+	if options.Dsn != "" {
+		var err error
+		dsn, err = NewDsn(options.Dsn)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	client := Client{
+		options: options,
+		dsn:     dsn,
+	}
+
+	client.setupTransport()
+	client.setupIntegrations()
+
+	return &client, nil
+}
+
+func (client *Client) setupTransport() {
+	transport := client.options.Transport
+
+	if transport == nil {
+		if client.options.Dsn == "" {
+			transport = new(noopTransport)
+		} else {
+			transport = NewHTTPTransport()
+		}
+	}
+
+	transport.Configure(client.options)
+	client.Transport = transport
+}
+
+func (client *Client) setupIntegrations() {
+	integrations := []Integration{
+		new(contextifyFramesIntegration),
+		new(environmentIntegration),
+		new(modulesIntegration),
+		new(ignoreErrorsIntegration),
+	}
+
+	if client.options.Integrations != nil {
+		integrations = client.options.Integrations(integrations)
+	}
+
+	for _, integration := range integrations {
+		if client.integrationAlreadyInstalled(integration.Name()) {
+			Logger.Printf("Integration %s is already installed\n", integration.Name())
+			continue
+		}
+		client.integrations = append(client.integrations, integration)
+		integration.SetupOnce(client)
+		Logger.Printf("Integration installed: %s\n", integration.Name())
+	}
+}
+
+// AddEventProcessor adds an event processor to the client.
+func (client *Client) AddEventProcessor(processor EventProcessor) {
+	client.eventProcessors = append(client.eventProcessors, processor)
+}
+
+// Options return `ClientOptions` for the current `Client`.
+func (client Client) Options() ClientOptions {
+	return client.options
+}
+
+// CaptureMessage captures an arbitrary message.
+func (client *Client) CaptureMessage(message string, hint *EventHint, scope EventModifier) *EventID {
+	event := client.eventFromMessage(message, LevelInfo)
+	return client.CaptureEvent(event, hint, scope)
+}
+
+// CaptureException captures an error.
+func (client *Client) CaptureException(exception error, hint *EventHint, scope EventModifier) *EventID {
+	event := client.eventFromException(exception, LevelError)
+	return client.CaptureEvent(event, hint, scope)
+}
+
+// CaptureEvent captures an event on the currently active client if any.
+//
+// The event must already be assembled. Typically code would instead use
+// the utility methods like `CaptureException`. The return value is the
+// event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
+func (client *Client) CaptureEvent(event *Event, hint *EventHint, scope EventModifier) *EventID {
+	return client.processEvent(event, hint, scope)
+}
+
+// Recover captures a panic.
+// Returns `EventID` if successfully, or `nil` if there's no error to recover from.
+func (client *Client) Recover(err interface{}, hint *EventHint, scope EventModifier) *EventID {
+	if err == nil {
+		err = recover()
+	}
+
+	if err != nil {
+		if err, ok := err.(error); ok {
+			event := client.eventFromException(err, LevelFatal)
+			return client.CaptureEvent(event, hint, scope)
+		}
+
+		if err, ok := err.(string); ok {
+			event := client.eventFromMessage(err, LevelFatal)
+			return client.CaptureEvent(event, hint, scope)
+		}
+	}
+
+	return nil
+}
+
+// Recover captures a panic and passes relevant context object.
+// Returns `EventID` if successfully, or `nil` if there's no error to recover from.
+func (client *Client) RecoverWithContext(
+	ctx context.Context,
+	err interface{},
+	hint *EventHint,
+	scope EventModifier,
+) *EventID {
+	if err == nil {
+		err = recover()
+	}
+
+	if err != nil {
+		if hint.Context == nil && ctx != nil {
+			hint.Context = ctx
+		}
+
+		if err, ok := err.(error); ok {
+			event := client.eventFromException(err, LevelFatal)
+			return client.CaptureEvent(event, hint, scope)
+		}
+
+		if err, ok := err.(string); ok {
+			event := client.eventFromMessage(err, LevelFatal)
+			return client.CaptureEvent(event, hint, scope)
+		}
+	}
+
+	return nil
+}
+
+// Flush notifies when all the buffered events have been sent by returning `true`
+// or `false` if timeout was reached. It calls `Flush` method of the configured `Transport`.
+func (client *Client) Flush(timeout time.Duration) bool {
+	return client.Transport.Flush(timeout)
+}
+
+func (client *Client) eventFromMessage(message string, level Level) *Event {
+	event := NewEvent()
+	event.Level = level
+	event.Message = message
+
+	if client.Options().AttachStacktrace {
+		event.Threads = []Thread{{
+			Stacktrace: NewStacktrace(),
+			Crashed:    false,
+			Current:    true,
+		}}
+	}
+
+	return event
+}
+
+func (client *Client) eventFromException(exception error, level Level) *Event {
+	if exception == nil {
+		event := NewEvent()
+		event.Level = level
+		event.Message = fmt.Sprintf("Called %s with nil value", callerFunctionName())
+		return event
+	}
+
+	stacktrace := ExtractStacktrace(exception)
+
+	if stacktrace == nil {
+		stacktrace = NewStacktrace()
+	}
+
+	event := NewEvent()
+	event.Level = level
+	event.Exception = []Exception{{
+		Value:      exception.Error(),
+		Type:       reflect.TypeOf(exception).String(),
+		Stacktrace: stacktrace,
+	}}
+	return event
+}
+
+func (client *Client) processEvent(event *Event, hint *EventHint, scope EventModifier) *EventID {
+	options := client.Options()
+
+	// TODO: Reconsider if its worth going away from default implementation
+	// of other SDKs. In Go zero value (default) for float32 is 0.0,
+	// which means that if someone uses ClientOptions{} struct directly
+	// and we would not check for 0 here, we'd skip all events by default
+	if options.SampleRate != 0.0 {
+		randomFloat := rand.New(rand.NewSource(time.Now().UnixNano())).Float32()
+		if randomFloat > options.SampleRate {
+			Logger.Println("Event dropped due to SampleRate hit.")
+			return nil
+		}
+	}
+
+	if event = client.prepareEvent(event, hint, scope); event == nil {
+		return nil
+	}
+
+	if options.BeforeSend != nil {
+		h := &EventHint{}
+		if hint != nil {
+			h = hint
+		}
+		if event = options.BeforeSend(event, h); event == nil {
+			Logger.Println("Event dropped due to BeforeSend callback.")
+			return nil
+		}
+	}
+
+	client.Transport.SendEvent(event)
+
+	return &event.EventID
+}
+
+func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventModifier) *Event {
+	if event.EventID == "" {
+		event.EventID = EventID(uuid())
+	}
+
+	if event.Timestamp == 0 {
+		event.Timestamp = time.Now().Unix()
+	}
+
+	if event.Level == "" {
+		event.Level = LevelInfo
+	}
+
+	if event.ServerName == "" {
+		if client.Options().ServerName != "" {
+			event.ServerName = client.Options().ServerName
+		} else if hostname, err := os.Hostname(); err == nil {
+			event.ServerName = hostname
+		}
+	}
+
+	if event.Release == "" && client.Options().Release != "" {
+		event.Release = client.Options().Release
+	}
+
+	if event.Dist == "" && client.Options().Dist != "" {
+		event.Dist = client.Options().Dist
+	}
+
+	if event.Environment == "" && client.Options().Environment != "" {
+		event.Environment = client.Options().Environment
+	}
+
+	event.Platform = "go"
+	event.Sdk = SdkInfo{
+		Name:         "sentry.go",
+		Version:      Version,
+		Integrations: client.listIntegrations(),
+		Packages: []SdkPackage{{
+			Name:    "sentry-go",
+			Version: Version,
+		}},
+	}
+
+	event = scope.ApplyToEvent(event, hint)
+
+	for _, processor := range client.eventProcessors {
+		id := event.EventID
+		event = processor(event, hint)
+		if event == nil {
+			Logger.Printf("Event dropped by one of the Client EventProcessors: %s\n", id)
+			return nil
+		}
+	}
+
+	for _, processor := range globalEventProcessors {
+		id := event.EventID
+		event = processor(event, hint)
+		if event == nil {
+			Logger.Printf("Event dropped by one of the Global EventProcessors: %s\n", id)
+			return nil
+		}
+	}
+
+	return event
+}
+
+func (client Client) listIntegrations() []string {
+	integrations := make([]string, 0, len(client.integrations))
+	for _, integration := range client.integrations {
+		integrations = append(integrations, integration.Name())
+	}
+	sort.Strings(integrations)
+	return integrations
+}
+
+func (client Client) integrationAlreadyInstalled(name string) bool {
+	for _, integration := range client.integrations {
+		if integration.Name() == name {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/getsentry/sentry-go/client_test.go
+++ b/vendor/github.com/getsentry/sentry-go/client_test.go
@@ -1,0 +1,120 @@
+package sentry
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewClientAllowsEmptyDSN(t *testing.T) {
+	transport := &TransportMock{}
+	client, err := NewClient(ClientOptions{
+		Transport: transport,
+	})
+	if err != nil {
+		t.Fatalf("expected no error when creating client without a DNS but got %v", err)
+	}
+
+	client.CaptureException(errors.New("custom error"), nil, &ScopeMock{})
+	assertEqual(t, transport.lastEvent.Exception[0].Value, "custom error")
+}
+
+type customComplexError struct {
+	Message string
+}
+
+func (e customComplexError) Error() string {
+	return "customComplexError: " + e.Message
+}
+
+func (e customComplexError) AnswerToLife() string {
+	return "42"
+}
+
+func setupClientTest() (*Client, *ScopeMock, *TransportMock) {
+	scope := &ScopeMock{}
+	transport := &TransportMock{}
+	client, _ := NewClient(ClientOptions{
+		Dsn:       "http://whatever@really.com/1337",
+		Transport: transport,
+		Integrations: func(i []Integration) []Integration {
+			return []Integration{}
+		},
+	})
+
+	return client, scope, transport
+}
+func TestCaptureMessageShouldSendEventWithProvidedMessage(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	client.CaptureMessage("foo", nil, scope)
+	assertEqual(t, transport.lastEvent.Message, "foo")
+}
+
+func TestCaptureExceptionShouldSendEventWithProvidedError(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	client.CaptureException(errors.New("custom error"), nil, scope)
+	assertEqual(t, transport.lastEvent.Exception[0].Value, "custom error")
+}
+
+func TestCaptureExceptionShouldNotFailWhenPassedNil(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	client.CaptureException(nil, nil, scope)
+	assertEqual(t, transport.lastEvent.Message, "Called CaptureException with nil value")
+}
+
+func TestCaptureEventShouldSendEventWithProvidedError(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	event := NewEvent()
+	event.Message = "event message"
+	client.CaptureEvent(event, nil, scope)
+	assertEqual(t, transport.lastEvent.Message, "event message")
+}
+
+func TestSampleRateCanDropEvent(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	client.options.SampleRate = 0.000000000000001
+
+	client.CaptureMessage("Foo", nil, scope)
+
+	if transport.lastEvent != nil {
+		t.Error("expected event to be dropped")
+	}
+}
+
+func TestApplyToScopeCanDropEvent(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	scope.shouldDropEvent = true
+
+	client.CaptureMessage("Foo", nil, scope)
+
+	if transport.lastEvent != nil {
+		t.Error("expected event to be dropped")
+	}
+}
+
+func TestBeforeSendCanDropEvent(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	client.options.BeforeSend = func(event *Event, hint *EventHint) *Event {
+		return nil
+	}
+
+	client.CaptureMessage("Foo", nil, scope)
+
+	if transport.lastEvent != nil {
+		t.Error("expected event to be dropped")
+	}
+}
+
+func TestBeforeSendGetAccessToEventHint(t *testing.T) {
+	client, scope, transport := setupClientTest()
+	client.options.BeforeSend = func(event *Event, hint *EventHint) *Event {
+		if ex, ok := hint.OriginalException.(customComplexError); ok {
+			event.Message = event.Exception[0].Value + " " + ex.AnswerToLife()
+		}
+		return event
+	}
+	ex := customComplexError{Message: "Foo"}
+
+	client.CaptureException(ex, &EventHint{OriginalException: ex}, scope)
+
+	assertEqual(t, transport.lastEvent.Message, "customComplexError: Foo 42")
+}

--- a/vendor/github.com/getsentry/sentry-go/dsn.go
+++ b/vendor/github.com/getsentry/sentry-go/dsn.go
@@ -1,0 +1,185 @@
+package sentry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type scheme string
+
+const (
+	schemeHTTP  scheme = "http"
+	schemeHTTPS scheme = "https"
+)
+
+func (scheme scheme) defaultPort() int {
+	switch scheme {
+	case schemeHTTPS:
+		return 443
+	case schemeHTTP:
+		return 80
+	default:
+		return 80
+	}
+}
+
+type DsnParseError struct {
+	Message string
+}
+
+func (e DsnParseError) Error() string {
+	return "[Sentry] DsnParseError: " + e.Message
+}
+
+// Dsn is used as the remote address source to client transport.
+type Dsn struct {
+	scheme    scheme
+	publicKey string
+	secretKey string
+	host      string
+	port      int
+	path      string
+	projectID int
+}
+
+// NewDsn creates an instance od `Dsn` by parsing provided url in a `string` format.
+// If Dsn is not set the client is effectively disabled.
+func NewDsn(rawURL string) (*Dsn, error) {
+	// Parse
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, &DsnParseError{"invalid url"}
+	}
+
+	// Scheme
+	var scheme scheme
+	switch parsedURL.Scheme {
+	case "http":
+		scheme = schemeHTTP
+	case "https":
+		scheme = schemeHTTPS
+	default:
+		return nil, &DsnParseError{"invalid scheme"}
+	}
+
+	// PublicKey
+	publicKey := parsedURL.User.Username()
+	if publicKey == "" {
+		return nil, &DsnParseError{"empty username"}
+	}
+
+	// SecretKey
+	var secretKey string
+	if parsedSecretKey, ok := parsedURL.User.Password(); ok {
+		secretKey = parsedSecretKey
+	}
+
+	// Host
+	host := parsedURL.Hostname()
+	if host == "" {
+		return nil, &DsnParseError{"empty host"}
+	}
+
+	// Port
+	var port int
+	if parsedURL.Port() != "" {
+		parsedPort, err := strconv.Atoi(parsedURL.Port())
+		if err != nil {
+			return nil, &DsnParseError{"invalid port"}
+		}
+		port = parsedPort
+	} else {
+		port = scheme.defaultPort()
+	}
+
+	// ProjectID
+	if len(parsedURL.Path) == 0 || parsedURL.Path == "/" {
+		return nil, &DsnParseError{"empty project id"}
+	}
+	pathSegments := strings.Split(parsedURL.Path[1:], "/")
+	projectID, err := strconv.Atoi(pathSegments[len(pathSegments)-1])
+	if err != nil {
+		return nil, &DsnParseError{"invalid project id"}
+	}
+
+	// Path
+	var path string
+	if len(pathSegments) > 1 {
+		path = "/" + strings.Join(pathSegments[0:len(pathSegments)-1], "/")
+	}
+
+	return &Dsn{
+		scheme:    scheme,
+		publicKey: publicKey,
+		secretKey: secretKey,
+		host:      host,
+		port:      port,
+		path:      path,
+		projectID: projectID,
+	}, nil
+}
+
+// String formats Dsn struct into a valid string url
+func (dsn Dsn) String() string {
+	var url string
+	url += fmt.Sprintf("%s://%s", dsn.scheme, dsn.publicKey)
+	if dsn.secretKey != "" {
+		url += fmt.Sprintf(":%s", dsn.secretKey)
+	}
+	url += fmt.Sprintf("@%s", dsn.host)
+	if dsn.port != dsn.scheme.defaultPort() {
+		url += fmt.Sprintf(":%d", dsn.port)
+	}
+	if dsn.path != "" {
+		url += dsn.path
+	}
+	url += fmt.Sprintf("/%d", dsn.projectID)
+	return url
+}
+
+// StoreAPIURL returns assembled url to be used in the transport.
+// It points to configures Sentry instance.
+func (dsn Dsn) StoreAPIURL() *url.URL {
+	var rawURL string
+	rawURL += fmt.Sprintf("%s://%s", dsn.scheme, dsn.host)
+	if dsn.port != dsn.scheme.defaultPort() {
+		rawURL += fmt.Sprintf(":%d", dsn.port)
+	}
+	rawURL += fmt.Sprintf("/api/%d/store/", dsn.projectID)
+	parsedURL, _ := url.Parse(rawURL)
+	return parsedURL
+}
+
+// RequestHeaders returns all the necessary headers that have to be used in the transport.
+func (dsn Dsn) RequestHeaders() map[string]string {
+	auth := fmt.Sprintf("Sentry sentry_version=%d, sentry_timestamp=%d, "+
+		"sentry_client=sentry.go/%s, sentry_key=%s", 7, time.Now().Unix(), Version, dsn.publicKey)
+
+	if dsn.secretKey != "" {
+		auth = fmt.Sprintf("%s, sentry_secret=%s", auth, dsn.secretKey)
+	}
+
+	return map[string]string{
+		"Content-Type":  "application/json",
+		"X-Sentry-Auth": auth,
+	}
+}
+
+func (dsn Dsn) MarshalJSON() ([]byte, error) {
+	return json.Marshal(dsn.String())
+}
+
+func (dsn *Dsn) UnmarshalJSON(data []byte) error {
+	var str string
+	_ = json.Unmarshal(data, &str)
+	newDsn, err := NewDsn(str)
+	if err != nil {
+		return err
+	}
+	*dsn = *newDsn
+	return nil
+}

--- a/vendor/github.com/getsentry/sentry-go/dsn_test.go
+++ b/vendor/github.com/getsentry/sentry-go/dsn_test.go
@@ -1,0 +1,210 @@
+package sentry
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+)
+
+func TestDsnParsing(t *testing.T) {
+	url := "https://username:password@domain:8888/foo/bar/23"
+	dsn, err := NewDsn(url)
+	if err != nil {
+		t.Error("expected dsn to be correctly created")
+	}
+	assertEqual(t, schemeHTTPS, dsn.scheme)
+	assertEqual(t, dsn.publicKey, "username")
+	assertEqual(t, dsn.secretKey, "password")
+	assertEqual(t, dsn.host, "domain")
+	assertEqual(t, dsn.path, "/foo/bar")
+	assertEqual(t, dsn.String(), url)
+	assertEqual(t, dsn.port, 8888)
+	assertEqual(t, dsn.projectID, 23)
+}
+
+func TestDsnDefaultPort(t *testing.T) {
+	dsn, _ := NewDsn("https://u@d:1337/23")
+	assertEqual(t, dsn.port, 1337)
+	dsn, _ = NewDsn("https://u@d/23")
+	assertEqual(t, dsn.port, 443)
+	dsn, _ = NewDsn("http://u@d/23")
+	assertEqual(t, dsn.port, 80)
+}
+
+func TestDsnSerializeDeserialize(t *testing.T) {
+	url := "https://username:password@domain:8888/foo/bar/23"
+	dsn, dsnErr := NewDsn(url)
+	serialized, _ := json.Marshal(dsn)
+	var deserialized Dsn
+	unmarshalErr := json.Unmarshal(serialized, &deserialized)
+
+	if unmarshalErr != nil {
+		t.Error("expected dsn unmarshal to not return error")
+	}
+	if dsnErr != nil {
+		t.Error("expected NewDsn to not return error")
+	}
+	assertEqual(t, "\"https://username:password@domain:8888/foo/bar/23\"", string(serialized))
+	assertEqual(t, url, deserialized.String())
+}
+
+func TestDsnDeserializeInvalidJSON(t *testing.T) {
+	var invalidJSON Dsn
+	invalidJSONErr := json.Unmarshal([]byte("\"whoops"), &invalidJSON)
+	var invalidDsn Dsn
+	invalidDsnErr := json.Unmarshal([]byte("\"http://wat\""), &invalidDsn)
+
+	if invalidJSONErr == nil {
+		t.Error("expected dsn unmarshal to return error")
+	}
+	if invalidDsnErr == nil {
+		t.Error("expected dsn unmarshal to return error")
+	}
+}
+
+func TestValidDsnInsecure(t *testing.T) {
+	url := "http://username@domain:8888/42"
+	dsn, err := NewDsn(url)
+
+	if err != nil {
+		t.Error("expected dsn to be correctly created")
+	}
+	assertEqual(t, url, dsn.String())
+}
+
+func TestValidDsnNoPort(t *testing.T) {
+	url := "http://username@domain/42"
+	dsn, err := NewDsn(url)
+
+	if err != nil {
+		t.Error("expected dsn to be correctly created")
+	}
+	assertEqual(t, 80, dsn.port)
+	assertEqual(t, url, dsn.String())
+	assertEqual(t, "http://domain/api/42/store/", dsn.StoreAPIURL().String())
+}
+
+func TestValidDsnInsecureNoPort(t *testing.T) {
+	url := "https://username@domain/42"
+	dsn, err := NewDsn(url)
+
+	if err != nil {
+		t.Error("expected dsn to be correctly created")
+	}
+	assertEqual(t, 443, dsn.port)
+	assertEqual(t, url, dsn.String())
+	assertEqual(t, "https://domain/api/42/store/", dsn.StoreAPIURL().String())
+}
+
+func TestValidDsnNoPassword(t *testing.T) {
+	url := "https://username@domain:8888/42"
+	dsn, err := NewDsn(url)
+
+	if err != nil {
+		t.Error("expected dsn to be correctly created")
+	}
+	assertEqual(t, url, dsn.String())
+	assertEqual(t, "https://domain:8888/api/42/store/", dsn.StoreAPIURL().String())
+}
+
+func TestInvalidDsnInvalidUrl(t *testing.T) {
+	_, err := NewDsn("!@#$%^&*()")
+	_, ok := err.(*DsnParseError)
+
+	if ok != true {
+		t.Error("expected error to be of type DsnParseError")
+	}
+	assertStringContains(t, err.Error(), "invalid url")
+}
+
+func TestInvalidDsnInvalidScheme(t *testing.T) {
+	_, err := NewDsn("ftp://username:password@domain:8888/1")
+	_, ok := err.(*DsnParseError)
+
+	if ok != true {
+		t.Error("expected error to be of type DsnParseError")
+	}
+	assertStringContains(t, err.Error(), "invalid scheme")
+}
+
+func TestInvalidDsnNoUsername(t *testing.T) {
+	_, err := NewDsn("https://:password@domain:8888/23")
+	_, ok := err.(*DsnParseError)
+
+	if ok != true {
+		t.Error("expected error to be of type DsnParseError")
+	}
+	assertStringContains(t, err.Error(), "empty username")
+}
+
+func TestInvalidDsnNoHost(t *testing.T) {
+	_, err := NewDsn("https://username:password@:8888/42")
+	_, ok := err.(*DsnParseError)
+
+	if ok != true {
+		t.Error("expected error to be of type DsnParseError")
+	}
+	assertStringContains(t, err.Error(), "empty host")
+}
+
+func TestInvalidDsnInvalidPort(t *testing.T) {
+	_, err := NewDsn("https://username:password@domain:wat/42")
+	_, ok := err.(*DsnParseError)
+
+	if ok != true {
+		t.Error("expected error to be of type DsnParseError")
+	}
+	assertStringContains(t, err.Error(), "invalid port")
+}
+
+func TestInvalidDsnNoProjectId(t *testing.T) {
+	_, err := NewDsn("https://username:password@domain:8888/")
+	_, ok := err.(*DsnParseError)
+
+	if ok != true {
+		t.Error("expected error to be of type DsnParseError")
+	}
+	assertStringContains(t, err.Error(), "empty project id")
+}
+
+func TestInvalidDsnInvalidProjectId(t *testing.T) {
+	_, err := NewDsn("https://username:password@domain:8888/wbvdf7^W#$")
+	_, ok := err.(*DsnParseError)
+
+	if ok != true {
+		t.Error("expected error to be of type DsnParseError")
+	}
+	assertStringContains(t, err.Error(), "invalid project id")
+}
+
+func TestRequestHeadersWithoutPassword(t *testing.T) {
+	url := "https://username@domain:8888/23"
+	dsn, _ := NewDsn(url)
+	headers := dsn.RequestHeaders()
+	authRegexp := regexp.MustCompile("^Sentry sentry_version=7, sentry_timestamp=\\d+, " +
+		"sentry_client=sentry.go/.+, sentry_key=username$")
+
+	if len(headers) != 2 {
+		t.Error("expected request to have 2 headers")
+	}
+	assertEqual(t, "application/json", headers["Content-Type"])
+	if authRegexp.FindStringIndex(headers["X-Sentry-Auth"]) == nil {
+		t.Error("expected auth header to fulfill provided pattern")
+	}
+}
+
+func TestRequestHeadersWithPassword(t *testing.T) {
+	url := "https://username:secret@domain:8888/23"
+	dsn, _ := NewDsn(url)
+	headers := dsn.RequestHeaders()
+	authRegexp := regexp.MustCompile("^Sentry sentry_version=7, sentry_timestamp=\\d+, " +
+		"sentry_client=sentry.go/.+, sentry_key=username, sentry_secret=secret$")
+
+	if len(headers) != 2 {
+		t.Error("expected request to have 2 headers")
+	}
+	assertEqual(t, "application/json", headers["Content-Type"])
+	if authRegexp.FindStringIndex(headers["X-Sentry-Auth"]) == nil {
+		t.Error("expected auth header to fulfill provided pattern")
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/echo/README.md
+++ b/vendor/github.com/getsentry/sentry-go/echo/README.md
@@ -1,0 +1,135 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry Echo Handler for Sentry-go SDK
+
+**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/echo
+
+**Example:** https://github.com/getsentry/sentry-go/tree/master/example/echo
+
+## Installation
+
+```sh
+go get github.com/getsentry/sentry-go/echo
+```
+
+```go
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/getsentry/sentry-go"
+    sentryecho "github.com/getsentry/sentry-go/echo"
+    "github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+}); err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+}
+
+// Then create your app
+app := echo.New()
+
+app.Use(middleware.Logger())
+app.Use(middleware.Recover())
+
+// Once it's done, you can attach the handler as one of your middleware
+app.Use(sentryecho.New(sentryecho.Options{}))
+
+// Set up routes
+app.GET("/", func(ctx echo.Context) error {
+    return ctx.String(http.StatusOK, "Hello, World!")
+})
+
+// And run it
+app.Logger.Fatal(app.Start(":3000"))
+```
+
+## Configuration
+
+`sentryecho` accepts a struct of `Options` that allows you to configure how the handler will behave.
+
+Currently it respects 3 options:
+
+```go
+// Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
+// as echo includes its own Recover middleware that handles http responses.
+Repanic bool
+// WaitForDelivery configures whether you want to block the request before moving forward with the response.
+// Because Echo's `Recover` handler doesn't restart the application,
+// it's safe to either skip this option or set it to `false`.
+WaitForDelivery bool
+// Timeout for the event delivery requests.
+Timeout time.Duration
+```
+
+## Usage
+
+`sentryecho` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the `echo.Context`, which makes it available throughout the rest of the request's lifetime.
+You can access it by using the `sentryecho.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
+And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
+
+**Keep in mind that `*sentry.Hub` won't be available in middleware attached before to `sentryecho`!**
+
+```go
+app := echo.New()
+
+app.Use(middleware.Logger())
+app.Use(middleware.Recover())
+
+app.Use(sentryecho.New(sentryecho.Options{
+	Repanic: true,
+}))
+
+app.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		if hub := sentryecho.GetHubFromContext(ctx); hub != nil {
+			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+		}
+		return next(ctx)
+	}
+})
+
+app.GET("/", func(ctx echo.Context) error {
+	if hub := sentryecho.GetHubFromContext(ctx); hub != nil {
+		hub.WithScope(func(scope *sentry.Scope) {
+			scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+			hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+		})
+	}
+	return ctx.String(http.StatusOK, "Hello, World!")
+})
+
+app.GET("/foo", func(ctx echo.Context) error {
+	// sentryecho handler will catch it just fine. Also, because we attached "someRandomTag"
+	// in the middleware before, it will be sent through as well
+	panic("y tho")
+})
+
+app.Logger.Fatal(app.Start(":3000"))
+```
+
+### Accessing Request in `BeforeSend` callback
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+    BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+        if hint.Context != nil {
+            if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+                // You have access to the original Request here
+            }
+        }
+
+        return event
+    },
+})
+```

--- a/vendor/github.com/getsentry/sentry-go/echo/sentryecho.go
+++ b/vendor/github.com/getsentry/sentry-go/echo/sentryecho.go
@@ -1,0 +1,83 @@
+package sentryecho
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/labstack/echo/v4"
+)
+
+const valuesKey = "sentry"
+
+type handler struct {
+	repanic         bool
+	waitForDelivery bool
+	timeout         time.Duration
+}
+
+type Options struct {
+	// Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
+	// as echo includes it's own Recover middleware what handles http responses.
+	Repanic bool
+	// WaitForDelivery configures whether you want to block the request before moving forward with the response.
+	// Because Echo's `Recover` handler doesn't restart the application,
+	// it's safe to either skip this option or set it to `false`.
+	WaitForDelivery bool
+	// Timeout for the event delivery requests.
+	Timeout time.Duration
+}
+
+// New returns a function that satisfies echo.HandlerFunc interface
+// It can be used with Use() methods.
+func New(options Options) echo.MiddlewareFunc {
+	handler := handler{
+		repanic:         false,
+		timeout:         time.Second * 2,
+		waitForDelivery: false,
+	}
+
+	if options.Repanic {
+		handler.repanic = true
+	}
+
+	if options.WaitForDelivery {
+		handler.waitForDelivery = true
+	}
+
+	return handler.handle
+}
+
+func (h *handler) handle(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		hub := sentry.CurrentHub().Clone()
+		hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(ctx.Request()))
+		ctx.Set(valuesKey, hub)
+		defer h.recoverWithSentry(hub, ctx.Request())
+		return next(ctx)
+	}
+}
+
+func (h *handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
+	if err := recover(); err != nil {
+		eventID := hub.RecoverWithContext(
+			context.WithValue(r.Context(), sentry.RequestContextKey, r),
+			err,
+		)
+		if eventID != nil && h.waitForDelivery {
+			hub.Flush(h.timeout)
+		}
+		if h.repanic {
+			panic(err)
+		}
+	}
+}
+
+// GetHubFromContext retrieves attached *sentry.Hub instance from echo.Context.
+func GetHubFromContext(ctx echo.Context) *sentry.Hub {
+	if hub, ok := ctx.Get(valuesKey).(*sentry.Hub); ok {
+		return hub
+	}
+	return nil
+}

--- a/vendor/github.com/getsentry/sentry-go/errors_test.go
+++ b/vendor/github.com/getsentry/sentry-go/errors_test.go
@@ -1,0 +1,37 @@
+package sentry
+
+import (
+	goErrors "github.com/go-errors/errors"
+	pingcapErrors "github.com/pingcap/errors"
+	pkgErrors "github.com/pkg/errors"
+)
+
+// NOTE: if you modify this file, you are also responsible for updating LoC position in Stacktrace tests
+
+func Trace() *Stacktrace {
+	return NewStacktrace()
+}
+
+func RedPkgErrorsRanger() error {
+	return BluePkgErrorsRanger()
+}
+
+func BluePkgErrorsRanger() error {
+	return pkgErrors.New("this is bad from pkgErrors")
+}
+
+func RedPingcapErrorsRanger() error {
+	return BluePingcapErrorsRanger()
+}
+
+func BluePingcapErrorsRanger() error {
+	return pingcapErrors.New("this is bad from pingcapErrors")
+}
+
+func RedGoErrorsRanger() error {
+	return BlueGoErrorsRanger()
+}
+
+func BlueGoErrorsRanger() error {
+	return goErrors.New("this is bad from goErrors")
+}

--- a/vendor/github.com/getsentry/sentry-go/example/basic/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/basic/main.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func prettyPrint(v interface{}) string {
+	pp, _ := json.MarshalIndent(v, "", "  ")
+	return string(pp)
+}
+
+type devNullTransport struct{}
+
+func (t *devNullTransport) Configure(options sentry.ClientOptions) {
+	dsn, _ := sentry.NewDsn(options.Dsn)
+	fmt.Println()
+	fmt.Println("Store Endpoint:", dsn.StoreAPIURL())
+	fmt.Println("Headers:", dsn.RequestHeaders())
+	fmt.Println()
+}
+func (t *devNullTransport) SendEvent(event *sentry.Event) {
+	fmt.Println("Faked Transport")
+}
+
+func (t *devNullTransport) Flush(timeout time.Duration) bool {
+	return true
+}
+
+func recoverHandler() {
+	defer sentry.Recover()
+	panic("ups")
+}
+
+func beforeSend() {
+	sentry.CaptureMessage("Drop me!")
+}
+
+func captureMessage() {
+	sentry.CaptureMessage("say what again. SAY WHAT again")
+}
+
+func configureScope() {
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetExtra("oristhis", "justfantasy")
+		scope.SetTag("isthis", "reallife")
+		scope.SetLevel(sentry.LevelFatal)
+		scope.SetUser(sentry.User{
+			ID: "1337",
+		})
+	})
+}
+
+func withScope() {
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetLevel(sentry.LevelFatal)
+		sentry.CaptureException(errors.New("say what again. SAY WHAT again"))
+	})
+}
+
+func addBreadcrumbs() {
+	sentry.AddBreadcrumb(&sentry.Breadcrumb{
+		Message: "Random breadcrumb 1",
+	})
+
+	sentry.AddBreadcrumb(&sentry.Breadcrumb{
+		Message: "Random breadcrumb 2",
+	})
+
+	sentry.AddBreadcrumb(&sentry.Breadcrumb{
+		Message: "Random breadcrumb 3",
+	})
+}
+
+func withScopeAndConfigureScope() {
+	sentry.WithScope(func(scope *sentry.Scope) {
+		sentry.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetExtras(map[string]interface{}{
+				"istillcant": 42,
+				"believe":    "that",
+			})
+			scope.SetTags(map[string]string{
+				"italready": "works",
+				"just":      "likethat",
+			})
+		})
+
+		event := sentry.NewEvent()
+		event.Message = "say what again. SAY WHAT again"
+		sentry.CaptureEvent(event)
+	})
+}
+
+type CustomComplexError struct {
+	Message      string
+	AnswerToLife int
+}
+
+func (e CustomComplexError) Error() string {
+	return "CustomComplexError: " + e.Message
+}
+
+func (e CustomComplexError) GimmeMoreData() string {
+	return strconv.Itoa(e.AnswerToLife)
+}
+
+func eventHint() {
+	sentry.CaptureException(CustomComplexError{Message: "Captured", AnswerToLife: 42})
+}
+
+func main() {
+	if err := sentry.Init(sentry.ClientOptions{
+		Debug:        true,
+		Dsn:          "https://hello@world.io/1337",
+		IgnoreErrors: []string{"^(?i)drop me"},
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if ex, ok := hint.OriginalException.(CustomComplexError); ok {
+				event.Message = event.Message + " - " + ex.GimmeMoreData()
+			}
+
+			fmt.Printf("%s\n\n", prettyPrint(event))
+
+			return event
+		},
+		BeforeBreadcrumb: func(breadcrumb *sentry.Breadcrumb, _ *sentry.BreadcrumbHint) *sentry.Breadcrumb {
+			if breadcrumb.Message == "Random breadcrumb 3" {
+				breadcrumb.Message = "Not so random breadcrumb 3"
+			}
+
+			fmt.Printf("%s\n\n", prettyPrint(breadcrumb))
+
+			return breadcrumb
+		},
+		SampleRate: 1,
+		Transport:  &devNullTransport{},
+		Integrations: func(integrations []sentry.Integration) []sentry.Integration {
+			return append(integrations, integrations[1])
+		},
+	}); err != nil {
+		panic(err)
+	}
+
+	beforeSend()
+	configureScope()
+	withScope()
+	captureMessage()
+	addBreadcrumbs()
+	withScopeAndConfigureScope()
+	recoverHandler()
+	eventHint()
+}

--- a/vendor/github.com/getsentry/sentry-go/example/echo/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/echo/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	sentryecho "github.com/getsentry/sentry-go/echo"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn: "https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if hint.Context != nil {
+				if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+					// You have access to the original Request
+					fmt.Println(req)
+				}
+			}
+			fmt.Println(event)
+			return event
+		},
+		Debug:            true,
+		AttachStacktrace: true,
+	})
+
+	app := echo.New()
+
+	app.Use(middleware.Logger())
+	app.Use(middleware.Recover())
+
+	app.Use(sentryecho.New(sentryecho.Options{
+		Repanic: true,
+	}))
+
+	app.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			if hub := sentryecho.GetHubFromContext(ctx); hub != nil {
+				hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+			}
+			return next(ctx)
+		}
+	})
+
+	app.GET("/", func(ctx echo.Context) error {
+		if hub := sentryecho.GetHubFromContext(ctx); hub != nil {
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+				hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+			})
+		}
+		return ctx.String(http.StatusOK, "Hello, World!")
+	})
+
+	app.GET("/foo", func(ctx echo.Context) error {
+		// sentryecho handler will catch it just fine, and because we attached "someRandomTag"
+		// in the middleware before, it will be sent through as well
+		panic("y tho")
+	})
+
+	app.Logger.Fatal(app.Start(":3000"))
+}

--- a/vendor/github.com/getsentry/sentry-go/example/flush/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/flush/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn:   "https://hello@world.io/1337",
+		Debug: true,
+	})
+
+	sentry.CaptureMessage("Event #1")
+	sentry.CaptureMessage("Event #2")
+	sentry.CaptureMessage("Event #3")
+
+	go func() {
+		sentry.CaptureMessage("Event #4")
+		sentry.CaptureMessage("Event #5")
+	}()
+
+	fmt.Println("=> Flushing transport buffer")
+
+	if sentry.Flush(time.Second * 2) {
+		fmt.Println("=> All queued events delivered!")
+	} else {
+		fmt.Println("=> Flush timeout reached")
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/example/gin/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/gin/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	sentrygin "github.com/getsentry/sentry-go/gin"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn: "https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if hint.Context != nil {
+				if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+					// You have access to the original Request
+					fmt.Println(req)
+				}
+			}
+			fmt.Println(event)
+			return event
+		},
+		Debug:            true,
+		AttachStacktrace: true,
+	})
+
+	app := gin.Default()
+
+	app.Use(sentrygin.New(sentrygin.Options{
+		Repanic: true,
+	}))
+
+	app.Use(func(ctx *gin.Context) {
+		if hub := sentrygin.GetHubFromContext(ctx); hub != nil {
+			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+		}
+		ctx.Next()
+	})
+
+	app.GET("/", func(ctx *gin.Context) {
+		if hub := sentrygin.GetHubFromContext(ctx); hub != nil {
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+				hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+			})
+		}
+		ctx.Status(http.StatusOK)
+	})
+
+	app.GET("/foo", func(ctx *gin.Context) {
+		// sentrygin handler will catch it just fine, and because we attached "someRandomTag"
+		// in the middleware before, it will be sent through as well
+		panic("y tho")
+	})
+
+	_ = app.Run(":3000")
+}

--- a/vendor/github.com/getsentry/sentry-go/example/http/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/http/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	sentryhttp "github.com/getsentry/sentry-go/http"
+)
+
+type handler struct{}
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
+		hub.WithScope(func(scope *sentry.Scope) {
+			scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+			hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+		})
+	}
+	rw.WriteHeader(http.StatusOK)
+}
+
+func enhanceSentryEvent(handler http.HandlerFunc) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
+			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+		}
+		handler(rw, r)
+	}
+}
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn: "https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if hint.Context != nil {
+				if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+					// You have access to the original Request
+					fmt.Println(req)
+				}
+			}
+			fmt.Println(event)
+			return event
+		},
+		Debug:            true,
+		AttachStacktrace: true,
+	})
+
+	sentryHandler := sentryhttp.New(sentryhttp.Options{
+		Repanic: true,
+	})
+
+	http.Handle("/", sentryHandler.Handle(&handler{}))
+	http.HandleFunc("/foo", sentryHandler.HandleFunc(
+		enhanceSentryEvent(func(rw http.ResponseWriter, r *http.Request) {
+			panic("y tho")
+		}),
+	))
+
+	fmt.Println("Listening and serving HTTP on :3000")
+
+	if err := http.ListenAndServe(":3000", nil); err != nil {
+		panic(err)
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/example/iris/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/iris/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	sentryiris "github.com/getsentry/sentry-go/iris"
+	"github.com/kataras/iris"
+)
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn: "https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if hint.Context != nil {
+				if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+					// You have access to the original Request
+					fmt.Println(req)
+				}
+			}
+			fmt.Println(event)
+			return event
+		},
+		Debug:            true,
+		AttachStacktrace: true,
+	})
+
+	app := iris.Default()
+
+	app.Use(sentryiris.New(sentryiris.Options{
+		Repanic: true,
+	}))
+
+	app.Use(func(ctx iris.Context) {
+		if hub := sentryiris.GetHubFromContext(ctx); hub != nil {
+			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+		}
+		ctx.Next()
+	})
+
+	app.Get("/", func(ctx iris.Context) {
+		if hub := sentryiris.GetHubFromContext(ctx); hub != nil {
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+				hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+			})
+		}
+		ctx.StatusCode(http.StatusOK)
+	})
+
+	app.Get("/foo", func(ctx iris.Context) {
+		// sentryiris handler will catch it just fine, and because we attached "someRandomTag"
+		// in the middleware before, it will be sent through as well
+		panic("y tho")
+	})
+
+	_ = app.Run(iris.Addr(":3000"))
+}

--- a/vendor/github.com/getsentry/sentry-go/example/martini/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/martini/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	sentrymartini "github.com/getsentry/sentry-go/martini"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/go-martini/martini"
+)
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn: "https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if hint.Context != nil {
+				if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+					// You have access to the original Request
+					fmt.Println(req)
+				}
+			}
+			fmt.Println(event)
+			return event
+		},
+		Debug:            true,
+		AttachStacktrace: true,
+	})
+
+	app := martini.Classic()
+
+	app.Use(sentrymartini.New(sentrymartini.Options{
+		Repanic: true,
+	}))
+
+	app.Use(func(rw http.ResponseWriter, r *http.Request, c martini.Context, hub *sentry.Hub) {
+		hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+	})
+
+	app.Get("/", func(rw http.ResponseWriter, r *http.Request, hub *sentry.Hub) {
+		hub.WithScope(func(scope *sentry.Scope) {
+			scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+			hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+		})
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	app.Get("/foo", func() string {
+		// sentrymartini handler will catch it just fine, and because we attached "someRandomTag"
+		// in the middleware before, it will be sent through as well
+		panic("y tho")
+	})
+
+	app.RunOnAddr(":3000")
+}

--- a/vendor/github.com/getsentry/sentry-go/example/multiclient/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/multiclient/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/getsentry/sentry-go"
+)
+
+type pickleIntegration struct{}
+
+func (pi *pickleIntegration) Name() string {
+	return "PickleIntegration"
+}
+
+func (pi *pickleIntegration) SetupOnce(client *sentry.Client) {
+	client.AddEventProcessor(pi.processor)
+}
+
+func (pi *pickleIntegration) processor(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+	event.Message = fmt.Sprintf("PickleRick Says: %s", event.Message)
+	return event
+}
+
+func main() {
+	scope1 := sentry.NewScope()
+	client1, _ := sentry.NewClient(sentry.ClientOptions{
+		Dsn: "https://hello@world.io/1",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			log.Println(event.Message)
+			return nil
+		},
+		Integrations: func(integrations []sentry.Integration) []sentry.Integration {
+			return append(integrations, &pickleIntegration{})
+		},
+	})
+	hub1 := sentry.NewHub(client1, scope1)
+
+	scope2 := sentry.NewScope()
+	client2, _ := sentry.NewClient(sentry.ClientOptions{
+		Dsn: "https://hello@world.io/2",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			log.Println(event.Message)
+			return nil
+		},
+	})
+	hub2 := sentry.NewHub(client2, scope2)
+
+	hub1.CaptureMessage("Hub: altered message by pickleIntegration")
+	hub2.CaptureMessage("Hub: _NOT_ altered message by pickleIntegration")
+
+	client1.CaptureMessage("Client: altered message by pickleIntegration", &sentry.EventHint{}, scope1)
+	client2.CaptureMessage("Client: _NOT_ altered message by pickleIntegration", &sentry.EventHint{}, scope2)
+}

--- a/vendor/github.com/getsentry/sentry-go/example/negroni/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/negroni/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	sentrynegroni "github.com/getsentry/sentry-go/negroni"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/urfave/negroni"
+)
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn: "https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if hint.Context != nil {
+				if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+					// You have access to the original Request
+					fmt.Println(req)
+				}
+			}
+			fmt.Println(event)
+			return event
+		},
+		Debug:            true,
+		AttachStacktrace: true,
+	})
+
+	app := negroni.Classic()
+
+	app.Use(sentrynegroni.New(sentrynegroni.Options{
+		Repanic: true,
+	}))
+
+	app.Use(negroni.HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		hub := sentry.GetHubFromContext(r.Context())
+		hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+		next(rw, r)
+	}))
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		hub := sentry.GetHubFromContext(r.Context())
+		hub.WithScope(func(scope *sentry.Scope) {
+			scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+			hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+		})
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/foo", func(rw http.ResponseWriter, r *http.Request) {
+		// sentrynagroni handler will catch it just fine, and because we attached "someRandomTag"
+		// in the middleware before, it will be sent through as well
+		panic("y tho")
+	})
+
+	app.UseHandler(mux)
+
+	_ = http.ListenAndServe(":3000", app)
+}

--- a/vendor/github.com/getsentry/sentry-go/example/recover/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/recover/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func prettyPrint(v interface{}) string {
+	pp, _ := json.MarshalIndent(v, "", "  ")
+	return string(pp)
+}
+
+func fooErr() {
+	barErr()
+}
+
+func barErr() {
+	bazErr()
+}
+
+func bazErr() {
+	panic(errors.New("sorry with error :("))
+}
+
+func fooMsg() {
+	barMsg()
+}
+
+func barMsg() {
+	bazMsg()
+}
+
+func bazMsg() {
+	panic("sorry with message :(")
+}
+
+func main() {
+	_ = sentry.Init(sentry.ClientOptions{
+		Debug:            true,
+		Dsn:              "https://hello@world.io/1337",
+		AttachStacktrace: true,
+		BeforeSend: func(e *sentry.Event, h *sentry.EventHint) *sentry.Event {
+			fmt.Println(prettyPrint(e))
+			return e
+		},
+	})
+
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetExtra("oristhis", "justfantasy")
+		scope.SetTag("isthis", "reallife")
+		scope.SetLevel(sentry.LevelFatal)
+		scope.SetUser(sentry.User{
+			ID: "1337",
+		})
+	})
+
+	func() {
+		defer sentry.Recover()
+		fooErr()
+	}()
+
+	func() {
+		defer sentry.Recover()
+		fooMsg()
+	}()
+
+	sentry.Flush(time.Second * 5)
+}

--- a/vendor/github.com/getsentry/sentry-go/example/synctransport/main.go
+++ b/vendor/github.com/getsentry/sentry-go/example/synctransport/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func main() {
+	sentrySyncTransport := sentry.NewHTTPSyncTransport()
+	sentrySyncTransport.Timeout = time.Second * 3
+
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn:       "https://hello@world.io/1337",
+		Debug:     true,
+		Transport: sentrySyncTransport,
+	})
+
+	go func() {
+		sentry.CaptureMessage("Event #1")
+		log.Println(1)
+		sentry.CaptureMessage("Event #2")
+		log.Println(2)
+	}()
+
+	sentry.CaptureMessage("Event #3")
+	log.Println(3)
+	sentry.CaptureMessage("Event #4")
+	log.Println(4)
+	sentry.CaptureMessage("Event #5")
+	log.Println(5)
+
+	go func() {
+		sentry.CaptureMessage("Event #6")
+		log.Println(6)
+		sentry.CaptureMessage("Event #7")
+		log.Println(7)
+	}()
+}

--- a/vendor/github.com/getsentry/sentry-go/gin/README.md
+++ b/vendor/github.com/getsentry/sentry-go/gin/README.md
@@ -1,0 +1,126 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry Gin Handler for Sentry-go SDK
+
+**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/gin
+
+**Example:** https://github.com/getsentry/sentry-go/tree/master/example/gin
+
+## Installation
+
+```sh
+go get github.com/getsentry/sentry-go/gin
+```
+
+```go
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/getsentry/sentry-go"
+    sentrygin "github.com/getsentry/sentry-go/gin"
+    "github.com/gin-gonic/gin"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+}); err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+}
+
+// Then create your app
+app := gin.Default()
+
+// Once it's done, you can attach the handler as one of your middleware
+app.Use(sentrygin.New(sentrygin.Options{}))
+
+// Set up routes
+app.GET("/", func(ctx gin.Context) {
+    ctx.String(http.StatusOK, "Hello world!")
+})
+
+// And run it
+app.Run(":3000")
+```
+
+## Configuration
+
+`sentrygin` accepts a struct of `Options` that allows you to configure how the handler will behave.
+
+Currently it respects 3 options:
+
+```go
+// Whether Sentry should repanic after recovery, in most cases it should be set to true,
+// as gin.Default includes its own Recovery middleware that handles http responses.
+Repanic         bool
+// Whether you want to block the request before moving forward with the response.
+// Because Gin's default `Recovery` handler doesn't restart the application,
+// it's safe to either skip this option or set it to `false`.
+WaitForDelivery bool
+// Timeout for the event delivery requests.
+Timeout         time.Duration
+```
+
+## Usage
+
+`sentrygin` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the `*gin.Context`, which makes it available throughout the rest of the request's lifetime.
+You can access it by using the `sentrygin.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
+And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
+
+**Keep in mind that `*sentry.Hub` won't be available in middleware attached before to `sentrygin`!**
+
+```go
+app := gin.Default()
+
+app.Use(sentrygin.New(sentrygin.Options{
+    Repanic: true,
+}))
+
+app.Use(func(ctx *gin.Context) {
+    if hub := sentrygin.GetHubFromContext(ctx); hub != nil {
+        hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+    }
+    ctx.Next()
+})
+
+app.GET("/", func(ctx *gin.Context) {
+    if hub := sentrygin.GetHubFromContext(ctx); hub != nil {
+        hub.WithScope(func(scope *sentry.Scope) {
+            scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+            hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+        })
+    }
+    ctx.Status(http.StatusOK)
+})
+
+app.GET("/foo", func(ctx *gin.Context) {
+    // sentrygin handler will catch it just fine. Also, because we attached "someRandomTag"
+    // in the middleware before, it will be sent through as well
+    panic("y tho")
+})
+
+app.Run(":3000")
+```
+
+### Accessing Request in `BeforeSend` callback
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+    BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+        if hint.Context != nil {
+            if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+                // You have access to the original Request here
+            }
+        }
+
+        return event
+    },
+})
+```

--- a/vendor/github.com/getsentry/sentry-go/gin/sentrygin.go
+++ b/vendor/github.com/getsentry/sentry-go/gin/sentrygin.go
@@ -1,0 +1,83 @@
+package sentrygin
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/gin-gonic/gin"
+)
+
+const valuesKey = "sentry"
+
+type handler struct {
+	repanic         bool
+	waitForDelivery bool
+	timeout         time.Duration
+}
+
+type Options struct {
+	// Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
+	// as gin.Default includes it's own Recovery middleware what handles http responses.
+	Repanic bool
+	// WaitForDelivery configures whether you want to block the request before moving forward with the response.
+	// Because Gin's default `Recovery` handler doesn't restart the application,
+	// it's safe to either skip this option or set it to `false`.
+	WaitForDelivery bool
+	// Timeout for the event delivery requests.
+	Timeout time.Duration
+}
+
+// New returns a function that satisfies gin.HandlerFunc interface
+// It can be used with Use() methods.
+func New(options Options) gin.HandlerFunc {
+	handler := handler{
+		repanic:         false,
+		timeout:         time.Second * 2,
+		waitForDelivery: false,
+	}
+
+	if options.Repanic {
+		handler.repanic = true
+	}
+
+	if options.WaitForDelivery {
+		handler.waitForDelivery = true
+	}
+
+	return handler.handle
+}
+
+func (h *handler) handle(ctx *gin.Context) {
+	hub := sentry.CurrentHub().Clone()
+	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(ctx.Request))
+	ctx.Set(valuesKey, hub)
+	defer h.recoverWithSentry(hub, ctx.Request)
+	ctx.Next()
+}
+
+func (h *handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
+	if err := recover(); err != nil {
+		eventID := hub.RecoverWithContext(
+			context.WithValue(r.Context(), sentry.RequestContextKey, r),
+			err,
+		)
+		if eventID != nil && h.waitForDelivery {
+			hub.Flush(h.timeout)
+		}
+		if h.repanic {
+			panic(err)
+		}
+	}
+}
+
+// GetHubFromContext retrieves attached *sentry.Hub instance from gin.Context.
+func GetHubFromContext(ctx *gin.Context) *sentry.Hub {
+	if hub, ok := ctx.Get(valuesKey); ok {
+		if hub, ok := hub.(*sentry.Hub); ok {
+			return hub
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getsentry/sentry-go/go.mod
+++ b/vendor/github.com/getsentry/sentry-go/go.mod
@@ -1,0 +1,7 @@
+module github.com/getsentry/sentry-go
+
+require (
+	github.com/go-errors/errors v1.0.1
+	github.com/pingcap/errors v0.11.1
+	github.com/pkg/errors v0.8.1
+)

--- a/vendor/github.com/getsentry/sentry-go/go.sum
+++ b/vendor/github.com/getsentry/sentry-go/go.sum
@@ -1,0 +1,6 @@
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
+github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/pingcap/errors v0.11.1 h1:BXFZ6MdDd2U1uJUa2sRAWTmm+nieEzuyYM0R4aUTcC8=
+github.com/pingcap/errors v0.11.1/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/github.com/getsentry/sentry-go/helpers_test.go
+++ b/vendor/github.com/getsentry/sentry-go/helpers_test.go
@@ -1,0 +1,61 @@
+package sentry
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func assertEqual(t *testing.T, got, want interface{}, userMessage ...interface{}) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		logFailedAssertion(t, formatUnequalValues(got, want), userMessage...)
+	}
+}
+
+func assertNotEqual(t *testing.T, got, want interface{}, userMessage ...interface{}) {
+	t.Helper()
+
+	if reflect.DeepEqual(got, want) {
+		logFailedAssertion(t, formatUnequalValues(got, want), userMessage...)
+	}
+}
+
+func assertStringContains(t *testing.T, input, substr string) {
+	t.Helper()
+
+	if !strings.Contains(input, substr) {
+		logFailedAssertion(t, fmt.Sprintf("expected '%s' to contain '%s'", input, substr))
+	}
+}
+
+func logFailedAssertion(t *testing.T, summary string, userMessage ...interface{}) {
+	t.Helper()
+	text := summary
+
+	if len(userMessage) > 0 {
+		if message, ok := userMessage[0].(string); ok {
+			if message != "" && len(userMessage) > 1 {
+				text = fmt.Sprintf(message, userMessage[1:]...) + text
+			} else if message != "" {
+				text = fmt.Sprint(message) + text
+			}
+		}
+	}
+
+	t.Error(text)
+}
+
+func formatUnequalValues(got, want interface{}) string {
+	var a, b string
+
+	if reflect.TypeOf(got) != reflect.TypeOf(want) {
+		a, b = fmt.Sprintf("%T(%#v)", got, got), fmt.Sprintf("%T(%#v)", want, want)
+	} else {
+		a, b = fmt.Sprintf("%#v", got), fmt.Sprintf("%#v", want)
+	}
+
+	return fmt.Sprintf("\ngot: %s\nwant: %s", a, b)
+}

--- a/vendor/github.com/getsentry/sentry-go/http/README.md
+++ b/vendor/github.com/getsentry/sentry-go/http/README.md
@@ -1,0 +1,135 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry net/http Handler for Sentry-go SDK
+
+**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/http
+
+**Example:** https://github.com/getsentry/sentry-go/tree/master/example/http
+
+## Installation
+
+```sh
+go get github.com/getsentry/sentry-go/http
+```
+
+```go
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/getsentry/sentry-go"
+    sentryhttp "github.com/getsentry/sentry-go/http"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+}); err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+}
+
+// Create an instance of sentryhttp
+sentryHandler := sentryhttp.New(sentryhttp.Options{})
+
+// Once it's done, you can setup routes and attach the handler as one of your middleware
+http.Handle("/", sentryHandler.Handle(&handler{}))
+http.HandleFunc("/foo", sentryHandler.HandleFunc(func(rw http.ResponseWriter, r *http.Request) {
+    panic("y tho")
+}))
+
+fmt.Println("Listening and serving HTTP on :3000")
+
+// And run it
+if err := http.ListenAndServe(":3000", nil); err != nil {
+    panic(err)
+}
+```
+
+## Configuration
+
+`sentryhttp` accepts a struct of `Options` that allows you to configure how the handler will behave.
+
+Currently it respects 3 options:
+
+```go
+// Whether Sentry should repanic after recovery, in most cases it should be set to true,
+// and you should gracefully handle http responses.
+Repanic         bool
+// Whether you want to block the request before moving forward with the response.
+// Useful, when you want to restart the process after it panics.
+WaitForDelivery bool
+// Timeout for the event delivery requests.
+Timeout         time.Duration
+```
+
+## Usage
+
+`sentryhttp` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
+You can access it by using the `sentry.GetHubFromContext()` method on the request itself in any of your proceeding middleware and routes.
+And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
+
+**Keep in mind that `*sentry.Hub` won't be available in middleware attached before to `sentryhttp`!**
+
+```go
+type handler struct{}
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
+		hub.WithScope(func(scope *sentry.Scope) {
+			scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+			hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+		})
+	}
+	rw.WriteHeader(http.StatusOK)
+}
+
+func enhanceSentryEvent(handler http.HandlerFunc) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
+			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+		}
+		handler(rw, r)
+	}
+}
+
+// Later in the code
+
+sentryHandler := sentryhttp.New(sentryhttp.Options{
+    Repanic: true,
+})
+
+http.Handle("/", sentryHandler.Handle(&handler{}))
+http.HandleFunc("/foo", sentryHandler.HandleFunc(
+    enhanceSentryEvent(func(rw http.ResponseWriter, r *http.Request) {
+        panic("y tho")
+    }),
+))
+
+fmt.Println("Listening and serving HTTP on :3000")
+
+if err := http.ListenAndServe(":3000", nil); err != nil {
+    panic(err)
+}
+```
+
+### Accessing Request in `BeforeSend` callback
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+    BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+        if hint.Context != nil {
+            if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+                // You have access to the original Request here
+            }
+        }
+
+        return event
+    },
+})
+```

--- a/vendor/github.com/getsentry/sentry-go/http/sentryhttp.go
+++ b/vendor/github.com/getsentry/sentry-go/http/sentryhttp.go
@@ -1,0 +1,90 @@
+package sentryhttp
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+type Handler struct {
+	repanic         bool
+	waitForDelivery bool
+	timeout         time.Duration
+}
+
+type Options struct {
+	// Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
+	// as iris.Default includes it's own Recovery middleware what handles http responses.
+	Repanic bool
+	// WaitForDelivery configures whether you want to block the request before moving forward with the response.
+	// Because Iris's default `Recovery` handler doesn't restart the application,
+	// it's safe to either skip this option or set it to `false`.
+	WaitForDelivery bool
+	// Timeout for the event delivery requests.
+	Timeout time.Duration
+}
+
+// New returns a struct that provides Handle and HandleFunc methods
+// that satisfy http.Handler and http.HandlerFunc interfaces.
+func New(options Options) *Handler {
+	handler := Handler{
+		repanic:         false,
+		timeout:         time.Second * 2,
+		waitForDelivery: false,
+	}
+
+	if options.Repanic {
+		handler.repanic = true
+	}
+
+	if options.WaitForDelivery {
+		handler.waitForDelivery = true
+	}
+
+	return &handler
+}
+
+// Handle wraps http.Handler and recovers from caught panics.
+func (h *Handler) Handle(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		hub := sentry.CurrentHub().Clone()
+		hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+		ctx := sentry.SetHubOnContext(
+			r.Context(),
+			hub,
+		)
+		defer h.recoverWithSentry(hub, r)
+		handler.ServeHTTP(rw, r.WithContext(ctx))
+	})
+}
+
+// HandleFunc wraps http.HandleFunc and recovers from caught panics.
+func (h *Handler) HandleFunc(handler http.HandlerFunc) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		hub := sentry.CurrentHub().Clone()
+		hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+		ctx := sentry.SetHubOnContext(
+			r.Context(),
+			hub,
+		)
+		defer h.recoverWithSentry(hub, r)
+		handler(rw, r.WithContext(ctx))
+	}
+}
+
+func (h *Handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
+	if err := recover(); err != nil {
+		eventID := hub.RecoverWithContext(
+			context.WithValue(r.Context(), sentry.RequestContextKey, r),
+			err,
+		)
+		if eventID != nil && h.waitForDelivery {
+			hub.Flush(h.timeout)
+		}
+		if h.repanic {
+			panic(err)
+		}
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/hub.go
+++ b/vendor/github.com/getsentry/sentry-go/hub.go
@@ -1,0 +1,277 @@
+package sentry
+
+import (
+	"context"
+	"time"
+)
+
+type contextKey int
+
+// HubContextKey is a context key used to store Hub on any context.Context type
+const HubContextKey = contextKey(1)
+
+// RequestContextKey is a context key used to store http.Request on the context passed to RecoverWithContext
+const RequestContextKey = contextKey(2)
+
+// Default maximum number of breadcrumbs added to an event. Can be overwritten `maxBreadcrumbs` option.
+const defaultMaxBreadcrumbs = 30
+
+// Absolute maximum number of breadcrumbs added to an event.
+// The `maxBreadcrumbs` option cannot be higher than this value.
+const maxBreadcrumbs = 100
+
+// Initial instance of the Hub that has no `Client` bound and an empty `Scope`
+var currentHub = NewHub(nil, NewScope()) // nolint: gochecknoglobals
+
+// Hub is the central object that can manages scopes and clients.
+//
+// This can be used to capture events and manage the scope.
+// The default hub that is available automatically.
+//
+// In most situations developers do not need to interface the hub. Instead
+// toplevel convenience functions are exposed that will automatically dispatch
+// to global (`CurrentHub`) hub.  In some situations this might not be
+// possible in which case it might become necessary to manually work with the
+// hub. This is for instance the case when working with async code.
+type Hub struct {
+	stack       *stack
+	lastEventID EventID
+}
+
+type layer struct {
+	client *Client
+	scope  *Scope
+}
+
+type stack []*layer
+
+// NewHub returns an instance of a `Hub` with provided `Client` and `Scope` bound.
+func NewHub(client *Client, scope *Scope) *Hub {
+	hub := Hub{
+		stack: &stack{{
+			client: client,
+			scope:  scope,
+		}},
+	}
+	return &hub
+}
+
+// CurrentHub returns an instance of previously initialized `Hub` stored in the global namespace.
+func CurrentHub() *Hub {
+	return currentHub
+}
+
+// LastEventID returns an ID of last captured event for the current `Hub`.
+func (hub *Hub) LastEventID() EventID {
+	return hub.lastEventID
+}
+
+func (hub *Hub) stackTop() *layer {
+	stack := hub.stack
+	if stack == nil || len(*stack) == 0 {
+		return nil
+	}
+	return (*stack)[len(*stack)-1]
+}
+
+// Clone returns a copy of the current Hub with top-most scope and client copied over.
+func (hub *Hub) Clone() *Hub {
+	return NewHub(hub.Client(), hub.Scope().Clone())
+}
+
+// Scope returns top-level `Scope` of the current `Hub` or `nil` if no `Scope` is bound.
+func (hub *Hub) Scope() *Scope {
+	top := hub.stackTop()
+	if top == nil {
+		return nil
+	}
+	return top.scope
+}
+
+// Scope returns top-level `Client` of the current `Hub` or `nil` if no `Client` is bound.
+func (hub *Hub) Client() *Client {
+	top := hub.stackTop()
+	if top == nil {
+		return nil
+	}
+	return top.client
+}
+
+// PushScope pushes a new scope for the current `Hub` and reuses previously bound `Client`.
+func (hub *Hub) PushScope() *Scope {
+	scope := hub.Scope().Clone()
+
+	*hub.stack = append(*hub.stack, &layer{
+		client: hub.Client(),
+		scope:  scope,
+	})
+
+	return scope
+}
+
+// PushScope pops the most recent scope for the current `Hub`.
+func (hub *Hub) PopScope() {
+	stack := *hub.stack
+	if len(stack) == 0 {
+		return
+	}
+	*hub.stack = stack[0 : len(stack)-1]
+}
+
+// BindClient binds a new `Client` for the current `Hub`.
+func (hub *Hub) BindClient(client *Client) {
+	hub.stackTop().client = client
+}
+
+// WithScope temporarily pushes a scope for a single call.
+//
+// A shorthand for:
+// PushScope()
+// f(scope)
+// PopScope()
+func (hub *Hub) WithScope(f func(scope *Scope)) {
+	scope := hub.PushScope()
+	defer hub.PopScope()
+	f(scope)
+}
+
+// ConfigureScope invokes a function that can modify the current scope.
+//
+// The function is passed a mutable reference to the `Scope` so that modifications
+// can be performed.
+func (hub *Hub) ConfigureScope(f func(scope *Scope)) {
+	f(hub.Scope())
+}
+
+// CaptureEvent calls the method of a same name on currently bound `Client` instance
+// passing it a top-level `Scope`.
+// Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
+func (hub *Hub) CaptureEvent(event *Event) *EventID {
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	return client.CaptureEvent(event, nil, scope)
+}
+
+// CaptureMessage calls the method of a same name on currently bound `Client` instance
+// passing it a top-level `Scope`.
+// Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
+func (hub *Hub) CaptureMessage(message string) *EventID {
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	return client.CaptureMessage(message, nil, scope)
+}
+
+// CaptureException calls the method of a same name on currently bound `Client` instance
+// passing it a top-level `Scope`.
+// Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
+func (hub *Hub) CaptureException(exception error) *EventID {
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	return client.CaptureException(exception, &EventHint{OriginalException: exception}, scope)
+}
+
+// AddBreadcrumb records a new breadcrumb.
+//
+// The total number of breadcrumbs that can be recorded are limited by the
+// configuration on the client.
+func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
+	client := hub.Client()
+
+	// If there's no client, just store it on the scope straight away
+	if client == nil {
+		hub.Scope().AddBreadcrumb(breadcrumb, maxBreadcrumbs)
+		return
+	}
+
+	options := client.Options()
+	max := defaultMaxBreadcrumbs
+
+	if options.MaxBreadcrumbs != 0 {
+		max = options.MaxBreadcrumbs
+	}
+
+	if max < 0 {
+		return
+	}
+
+	if options.BeforeBreadcrumb != nil {
+		h := &BreadcrumbHint{}
+		if hint != nil {
+			h = hint
+		}
+		if breadcrumb = options.BeforeBreadcrumb(breadcrumb, h); breadcrumb == nil {
+			Logger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
+			return
+		}
+	}
+
+	if max > maxBreadcrumbs {
+		max = maxBreadcrumbs
+	}
+	hub.Scope().AddBreadcrumb(breadcrumb, max)
+}
+
+// Recover calls the method of a same name on currently bound `Client` instance
+// passing it a top-level `Scope`.
+// Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
+func (hub *Hub) Recover(err interface{}) *EventID {
+	if err == nil {
+		err = recover()
+	}
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	return client.Recover(err, &EventHint{RecoveredException: err}, scope)
+}
+
+// RecoverWithContext calls the method of a same name on currently bound `Client` instance
+// passing it a top-level `Scope`.
+// Returns `EventID` if successfully, or `nil` if there's no `Scope` or `Client` available.
+func (hub *Hub) RecoverWithContext(ctx context.Context, err interface{}) *EventID {
+	if err == nil {
+		err = recover()
+	}
+	client, scope := hub.Client(), hub.Scope()
+	if client == nil || scope == nil {
+		return nil
+	}
+	return client.RecoverWithContext(ctx, err, &EventHint{RecoveredException: err}, scope)
+}
+
+// Flush calls the method of a same name on currently bound `Client` instance.
+func (hub *Hub) Flush(timeout time.Duration) bool {
+	client := hub.Client()
+
+	if client == nil {
+		return false
+	}
+
+	return client.Flush(timeout)
+}
+
+// HasHubOnContext checks whether `Hub` instance is bound to a given `Context` struct.
+func HasHubOnContext(ctx context.Context) bool {
+	_, ok := ctx.Value(HubContextKey).(*Hub)
+	return ok
+}
+
+// GetHubFromContext tries to retrieve `Hub` instance from the given `Context` struct
+// or return `nil` if one is not found.
+func GetHubFromContext(ctx context.Context) *Hub {
+	if hub, ok := ctx.Value(HubContextKey).(*Hub); ok {
+		return hub
+	}
+	return nil
+}
+
+// SetHubOnContext stores given `Hub` instance on the `Context` struct and returns a new `Context`.
+func SetHubOnContext(ctx context.Context, hub *Hub) context.Context {
+	return context.WithValue(ctx, HubContextKey, hub)
+}

--- a/vendor/github.com/getsentry/sentry-go/hub_test.go
+++ b/vendor/github.com/getsentry/sentry-go/hub_test.go
@@ -1,0 +1,327 @@
+package sentry
+
+import (
+	"context"
+	"testing"
+)
+
+func setupHubTest() (*Hub, *Client, *Scope) {
+	client, _ := NewClient(ClientOptions{Dsn: "http://whatever@really.com/1337"})
+	scope := NewScope()
+	hub := NewHub(client, scope)
+	return hub, client, scope
+}
+
+func TestNewHubPushesLayerOnTopOfStack(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	assertEqual(t, len(*hub.stack), 1)
+}
+
+func TestNewHubLayerStoresClientAndScope(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	assertEqual(t, &layer{client: client, scope: scope}, (*hub.stack)[0])
+}
+
+func TestCloneHubInheritsClientAndScope(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	clone := hub.Clone()
+
+	if hub == clone {
+		t.Error("Cloned hub should be a new instance")
+	}
+
+	if clone.Client() != client {
+		t.Error("Client should be inherited")
+	}
+
+	if clone.Scope() == scope {
+		t.Error("Scope should be cloned, not reused")
+	}
+
+	assertEqual(t, clone.Scope(), scope)
+}
+
+func TestPushScopeAddsScopeOnTopOfStack(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	hub.PushScope()
+	assertEqual(t, len(*hub.stack), 2)
+}
+
+func TestPushScopeInheritsScopeData(t *testing.T) {
+	hub, _, scope := setupHubTest()
+	scope.SetExtra("foo", "bar")
+	hub.PushScope()
+	scope.SetExtra("baz", "qux")
+
+	if (*hub.stack)[0].scope == (*hub.stack)[1].scope {
+		t.Error("Scope shouldnt point to the same struct")
+	}
+	assertEqual(t, map[string]interface{}{"foo": "bar", "baz": "qux"}, (*hub.stack)[0].scope.extra)
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, (*hub.stack)[1].scope.extra)
+}
+
+func TestPushScopeInheritsClient(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	hub.PushScope()
+
+	if (*hub.stack)[0].client != (*hub.stack)[1].client {
+		t.Error("Client should be inherited")
+	}
+}
+
+func TestPopScopeRemovesLayerFromTheStack(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	hub.PushScope()
+	hub.PushScope()
+	hub.PopScope()
+
+	assertEqual(t, len(*hub.stack), 2)
+}
+
+func TestPopScopeCannotRemoveFromEmptyStack(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	assertEqual(t, len(*hub.stack), 1)
+	hub.PopScope()
+	assertEqual(t, len(*hub.stack), 0)
+	hub.PopScope()
+	assertEqual(t, len(*hub.stack), 0)
+}
+
+func TestBindClient(t *testing.T) {
+	hub, client, _ := setupHubTest()
+	hub.PushScope()
+	newClient, _ := NewClient(ClientOptions{Dsn: "http://whatever@really.com/1337"})
+	hub.BindClient(newClient)
+
+	if (*hub.stack)[0].client == (*hub.stack)[1].client {
+		t.Error("Two stack layers should have different clients bound")
+	}
+	if (*hub.stack)[0].client != client {
+		t.Error("Stack's parent layer should have old client bound")
+	}
+	if (*hub.stack)[1].client != newClient {
+		t.Error("Stack's top layer should have new client bound")
+	}
+}
+
+func TestWithScopeCreatesIsolatedScope(t *testing.T) {
+	hub, _, _ := setupHubTest()
+
+	hub.WithScope(func(scope *Scope) {
+		assertEqual(t, len(*hub.stack), 2)
+	})
+
+	assertEqual(t, len(*hub.stack), 1)
+}
+
+func TestWithScopeBindClient(t *testing.T) {
+	hub, client, _ := setupHubTest()
+
+	hub.WithScope(func(scope *Scope) {
+		newClient, _ := NewClient(ClientOptions{Dsn: "http://whatever@really.com/1337"})
+		hub.BindClient(newClient)
+		if hub.stackTop().client != newClient {
+			t.Error("should use newly bound client")
+		}
+	})
+
+	if hub.stackTop().client != client {
+		t.Error("should use old client")
+	}
+}
+
+func TestWithScopeDirectChanges(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	hub.Scope().SetExtra("foo", "bar")
+
+	hub.WithScope(func(scope *Scope) {
+		scope.SetExtra("foo", "baz")
+		assertEqual(t, map[string]interface{}{"foo": "baz"}, hub.stackTop().scope.extra)
+	})
+
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, hub.stackTop().scope.extra)
+}
+
+func TestWithScopeChangesThroughConfigureScope(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	hub.Scope().SetExtra("foo", "bar")
+
+	hub.WithScope(func(scope *Scope) {
+		hub.ConfigureScope(func(scope *Scope) {
+			scope.SetExtra("foo", "baz")
+		})
+		assertEqual(t, map[string]interface{}{"foo": "baz"}, hub.stackTop().scope.extra)
+	})
+
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, hub.stackTop().scope.extra)
+}
+
+func TestConfigureScope(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	hub.Scope().SetExtra("foo", "bar")
+
+	hub.ConfigureScope(func(scope *Scope) {
+		scope.SetExtra("foo", "baz")
+		assertEqual(t, map[string]interface{}{"foo": "baz"}, hub.stackTop().scope.extra)
+	})
+
+	assertEqual(t, map[string]interface{}{"foo": "baz"}, hub.stackTop().scope.extra)
+}
+
+func TestLastEventID(t *testing.T) {
+	uuid := EventID(uuid())
+	hub := &Hub{lastEventID: uuid}
+	assertEqual(t, uuid, hub.LastEventID())
+}
+
+func TestLayerAccessingEmptyStack(t *testing.T) {
+	hub := &Hub{}
+	if hub.stackTop() != nil {
+		t.Error("expected nil to be returned")
+	}
+}
+
+func TestLayerAccessingScopeReturnsNilIfStackIsEmpty(t *testing.T) {
+	hub := &Hub{}
+	if hub.Scope() != nil {
+		t.Error("expected nil to be returned")
+	}
+}
+
+func TestLayerAccessingClientReturnsNilIfStackIsEmpty(t *testing.T) {
+	hub := &Hub{}
+	if hub.Client() != nil {
+		t.Error("expected nil to be returned")
+	}
+}
+
+func TestAddBreadcrumbRespectMaxBreadcrumbsOption(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	client.options.MaxBreadcrumbs = 2
+
+	breadcrumb := &Breadcrumb{Message: "Breadcrumb"}
+
+	hub.AddBreadcrumb(breadcrumb, nil)
+	hub.AddBreadcrumb(breadcrumb, nil)
+	hub.AddBreadcrumb(breadcrumb, nil)
+
+	assertEqual(t, len(scope.breadcrumbs), 2)
+}
+
+func TestAddBreadcrumbSkipAllBreadcrumbsIfMaxBreadcrumbsIsLessThanZero(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	client.options.MaxBreadcrumbs = -1
+
+	breadcrumb := &Breadcrumb{Message: "Breadcrumb"}
+
+	hub.AddBreadcrumb(breadcrumb, nil)
+	hub.AddBreadcrumb(breadcrumb, nil)
+	hub.AddBreadcrumb(breadcrumb, nil)
+
+	assertEqual(t, len(scope.breadcrumbs), 0)
+}
+
+func TestAddBreadcrumbShouldNeverExceedMaxBreadcrumbsConst(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	client.options.MaxBreadcrumbs = 1000
+
+	breadcrumb := &Breadcrumb{Message: "Breadcrumb"}
+
+	for i := 0; i < 111; i++ {
+		hub.AddBreadcrumb(breadcrumb, nil)
+	}
+
+	assertEqual(t, len(scope.breadcrumbs), 100)
+}
+
+func TestAddBreadcrumbShouldWorkWithoutClient(t *testing.T) {
+	scope := NewScope()
+	hub := NewHub(nil, scope)
+
+	breadcrumb := &Breadcrumb{Message: "Breadcrumb"}
+	for i := 0; i < 111; i++ {
+		hub.AddBreadcrumb(breadcrumb, nil)
+	}
+
+	assertEqual(t, len(scope.breadcrumbs), 100)
+}
+
+func TestAddBreadcrumbCallsBeforeBreadcrumbCallback(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	client.options.BeforeBreadcrumb = func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb {
+		breadcrumb.Message += "_wat"
+		return breadcrumb
+	}
+
+	hub.AddBreadcrumb(&Breadcrumb{Message: "Breadcrumb"}, nil)
+
+	assertEqual(t, len(scope.breadcrumbs), 1)
+	assertEqual(t, "Breadcrumb_wat", scope.breadcrumbs[0].Message)
+}
+
+func TestBeforeBreadcrumbCallbackCanDropABreadcrumb(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	client.options.BeforeBreadcrumb = func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb {
+		return nil
+	}
+
+	hub.AddBreadcrumb(&Breadcrumb{Message: "Breadcrumb"}, nil)
+	hub.AddBreadcrumb(&Breadcrumb{Message: "Breadcrumb"}, nil)
+
+	assertEqual(t, len(scope.breadcrumbs), 0)
+}
+
+func TestBeforeBreadcrumbGetAccessToEventHint(t *testing.T) {
+	hub, client, scope := setupHubTest()
+	client.options.BeforeBreadcrumb = func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb {
+		if val, ok := (*hint)["foo"]; ok {
+			if val, ok := val.(string); ok {
+				breadcrumb.Message += val
+			}
+		}
+
+		return breadcrumb
+	}
+
+	hub.AddBreadcrumb(&Breadcrumb{Message: "Breadcrumb"}, &BreadcrumbHint{"foo": "_oh"})
+
+	assertEqual(t, len(scope.breadcrumbs), 1)
+	assertEqual(t, "Breadcrumb_oh", scope.breadcrumbs[0].Message)
+}
+
+func TestHasHubOnContextReturnsTrueIfHubIsThere(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	ctx := context.Background()
+	ctx = SetHubOnContext(ctx, hub)
+	assertEqual(t, true, HasHubOnContext(ctx))
+}
+
+func TestHasHubOnContextReturnsFalseIfHubIsNotThere(t *testing.T) {
+	ctx := context.Background()
+	assertEqual(t, false, HasHubOnContext(ctx))
+}
+
+func TestGetHubFromContext(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	ctx := context.Background()
+	ctx = SetHubOnContext(ctx, hub)
+	hubFromContext := GetHubFromContext(ctx)
+	assertEqual(t, hub, hubFromContext)
+}
+
+func TestGetHubFromContextReturnsNilIfHubIsNotThere(t *testing.T) {
+	ctx := context.Background()
+	hub := GetHubFromContext(ctx)
+	if hub != nil {
+		t.Error("hub shouldnt be available on empty context")
+	}
+}
+
+func TestSetHubOnContextReturnsNewContext(t *testing.T) {
+	hub, _, _ := setupHubTest()
+	ctx := context.Background()
+	ctxWithHub := SetHubOnContext(ctx, hub)
+	if ctx == ctxWithHub {
+		t.Error("contexts should be different")
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/integrations.go
+++ b/vendor/github.com/getsentry/sentry-go/integrations.go
@@ -1,0 +1,365 @@
+package sentry
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// ================================
+// Modules Integration
+// ================================
+
+type modulesIntegration struct{}
+
+var _modulesCache map[string]string // nolint: gochecknoglobals
+
+func (mi *modulesIntegration) Name() string {
+	return "Modules"
+}
+
+func (mi *modulesIntegration) SetupOnce(client *Client) {
+	client.AddEventProcessor(mi.processor)
+}
+
+func (mi *modulesIntegration) processor(event *Event, hint *EventHint) *Event {
+	if event.Modules == nil {
+		event.Modules = extractModules()
+	}
+
+	return event
+}
+
+func extractModules() map[string]string {
+	if _modulesCache != nil {
+		return _modulesCache
+	}
+
+	extractedModules, err := getModules()
+	if err != nil {
+		Logger.Printf("ModuleIntegration wasn't able to extract modules: %v\n", err)
+		return nil
+	}
+
+	_modulesCache = extractedModules
+
+	return extractedModules
+}
+
+func getModules() (map[string]string, error) {
+	if fileExists("go.mod") {
+		return getModulesFromMod()
+	}
+
+	if fileExists("vendor") {
+		// Priority given to vendor created by modules
+		if fileExists("vendor/modules.txt") {
+			return getModulesFromVendorTxt()
+		}
+
+		if fileExists("vendor/vendor.json") {
+			return getModulesFromVendorJSON()
+		}
+	}
+
+	return nil, fmt.Errorf("module integration failed")
+}
+
+func getModulesFromMod() (map[string]string, error) {
+	modules := make(map[string]string)
+
+	file, err := os.Open("go.mod")
+	if err != nil {
+		return nil, fmt.Errorf("unable to open mod file")
+	}
+
+	defer file.Close()
+
+	areModulesPresent := false
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		splits := strings.Split(scanner.Text(), " ")
+
+		if splits[0] == "require" {
+			areModulesPresent = true
+
+			// Mod file has only 1 dependency
+			if len(splits) > 2 {
+				modules[strings.TrimSpace(splits[1])] = splits[2]
+				return modules, nil
+			}
+		} else if areModulesPresent && splits[0] != ")" {
+			modules[strings.TrimSpace(splits[0])] = splits[1]
+		}
+	}
+
+	if scannerErr := scanner.Err(); scannerErr != nil {
+		return nil, scannerErr
+	}
+
+	return modules, nil
+}
+
+func getModulesFromVendorTxt() (map[string]string, error) {
+	modules := make(map[string]string)
+
+	file, err := os.Open("vendor/modules.txt")
+	if err != nil {
+		return nil, fmt.Errorf("unable to open vendor/modules.txt")
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		splits := strings.Split(scanner.Text(), " ")
+
+		if splits[0] == "#" {
+			modules[splits[1]] = splits[2]
+		}
+	}
+
+	if scannerErr := scanner.Err(); scannerErr != nil {
+		return nil, scannerErr
+	}
+
+	return modules, nil
+}
+
+func getModulesFromVendorJSON() (map[string]string, error) {
+	modules := make(map[string]string)
+
+	file, err := ioutil.ReadFile("vendor/vendor.json")
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to open vendor/vendor.json")
+	}
+
+	var vendor map[string]interface{}
+	if unmarshalErr := json.Unmarshal(file, &vendor); unmarshalErr != nil {
+		return nil, unmarshalErr
+	}
+
+	packages := vendor["package"].([]interface{})
+
+	// To avoid iterative dependencies, TODO: Change of default value
+	lastPath := "\n"
+
+	for _, value := range packages {
+		path := value.(map[string]interface{})["path"].(string)
+
+		if !strings.Contains(path, lastPath) {
+			// No versions are available through vendor.json
+			modules[path] = ""
+			lastPath = path
+		}
+	}
+
+	return modules, nil
+}
+
+// ================================
+// Environment Integration
+// ================================
+
+type environmentIntegration struct{}
+
+func (ei *environmentIntegration) Name() string {
+	return "Environment"
+}
+
+func (ei *environmentIntegration) SetupOnce(client *Client) {
+	client.AddEventProcessor(ei.processor)
+}
+
+func (ei *environmentIntegration) processor(event *Event, hint *EventHint) *Event {
+	if event.Contexts == nil {
+		event.Contexts = make(map[string]interface{})
+	}
+
+	event.Contexts["device"] = map[string]interface{}{
+		"arch":    runtime.GOARCH,
+		"num_cpu": runtime.NumCPU(),
+	}
+
+	event.Contexts["os"] = map[string]interface{}{
+		"name": runtime.GOOS,
+	}
+
+	event.Contexts["runtime"] = map[string]interface{}{
+		"name":    "go",
+		"version": runtime.Version(),
+	}
+
+	return event
+}
+
+// ================================
+// Ignore Errors Integration
+// ================================
+
+type ignoreErrorsIntegration struct {
+	ignoreErrors []*regexp.Regexp
+}
+
+func (iei *ignoreErrorsIntegration) Name() string {
+	return "IgnoreErrors"
+}
+
+func (iei *ignoreErrorsIntegration) SetupOnce(client *Client) {
+	iei.ignoreErrors = transformStringsIntoRegexps(client.Options().IgnoreErrors)
+	client.AddEventProcessor(iei.processor)
+}
+
+func (iei *ignoreErrorsIntegration) processor(event *Event, hint *EventHint) *Event {
+	suspects := getIgnoreErrorsSuspects(event)
+
+	for _, suspect := range suspects {
+		for _, pattern := range iei.ignoreErrors {
+			if pattern.Match([]byte(suspect)) {
+				Logger.Printf("Event dropped due to being matched by `IgnoreErrors` option."+
+					"| Value matched: %s | Filter used: %s", suspect, pattern)
+				return nil
+			}
+		}
+	}
+
+	return event
+}
+
+func transformStringsIntoRegexps(strings []string) []*regexp.Regexp {
+	var exprs []*regexp.Regexp
+
+	for _, s := range strings {
+		r, err := regexp.Compile(s)
+		if err == nil {
+			exprs = append(exprs, r)
+		}
+	}
+
+	return exprs
+}
+
+func getIgnoreErrorsSuspects(event *Event) []string {
+	suspects := []string{}
+
+	if event.Message != "" {
+		suspects = append(suspects, event.Message)
+	}
+
+	for _, ex := range event.Exception {
+		suspects = append(suspects, ex.Type)
+		suspects = append(suspects, ex.Value)
+	}
+
+	return suspects
+}
+
+// ================================
+// Contextify Frames Integration
+// ================================
+
+type contextifyFramesIntegration struct {
+	sr              sourceReader
+	contextLines    int
+	cachedLocations map[string]string
+}
+
+func (cfi *contextifyFramesIntegration) Name() string {
+	return "ContextifyFrames"
+}
+
+func (cfi *contextifyFramesIntegration) SetupOnce(client *Client) {
+	cfi.sr = newSourceReader()
+	cfi.contextLines = 5
+	cfi.cachedLocations = make(map[string]string)
+
+	client.AddEventProcessor(cfi.processor)
+}
+
+func (cfi *contextifyFramesIntegration) processor(event *Event, hint *EventHint) *Event {
+	// Range over all exceptions
+	for _, ex := range event.Exception {
+		// If it has no stacktrace, just bail out
+		if ex.Stacktrace == nil {
+			continue
+		}
+
+		// If it does, it should have frames, so try to contextify them
+		ex.Stacktrace.Frames = cfi.contextify(ex.Stacktrace.Frames)
+	}
+
+	return event
+}
+
+func (cfi *contextifyFramesIntegration) contextify(frames []Frame) []Frame {
+	contextifiedFrames := make([]Frame, 0, len(frames))
+
+	for _, frame := range frames {
+		if !frame.InApp {
+			contextifiedFrames = append(contextifiedFrames, frame)
+			continue
+		}
+
+		var path string
+
+		if cachedPath, ok := cfi.cachedLocations[frame.AbsPath]; ok {
+			path = cachedPath
+		} else {
+			// Optimize for happy path here
+			if fileExists(frame.AbsPath) {
+				path = frame.AbsPath
+			} else {
+				path = cfi.findNearbySourceCodeLocation(frame.AbsPath)
+			}
+		}
+
+		if path == "" {
+			contextifiedFrames = append(contextifiedFrames, frame)
+			continue
+		}
+
+		lines, contextLine := cfi.sr.readContextLines(path, frame.Lineno, cfi.contextLines)
+		contextifiedFrames = append(contextifiedFrames, cfi.addContextLinesToFrame(frame, lines, contextLine))
+	}
+
+	return contextifiedFrames
+}
+
+func (cfi *contextifyFramesIntegration) findNearbySourceCodeLocation(originalPath string) string {
+	trimmedPath := strings.TrimPrefix(originalPath, "/")
+	components := strings.Split(trimmedPath, "/")
+
+	for len(components) > 0 {
+		components = components[1:]
+		possibleLocation := strings.Join(components, "/")
+
+		if fileExists(possibleLocation) {
+			cfi.cachedLocations[originalPath] = possibleLocation
+			return possibleLocation
+		}
+	}
+
+	cfi.cachedLocations[originalPath] = ""
+	return ""
+}
+
+func (cfi *contextifyFramesIntegration) addContextLinesToFrame(frame Frame, lines [][]byte, contextLine int) Frame {
+	for i, line := range lines {
+		switch {
+		case i < contextLine:
+			frame.PreContext = append(frame.PreContext, string(line))
+		case i == contextLine:
+			frame.ContextLine = string(line)
+		default:
+			frame.PostContext = append(frame.PostContext, string(line))
+		}
+	}
+	return frame
+}

--- a/vendor/github.com/getsentry/sentry-go/integrations_test.go
+++ b/vendor/github.com/getsentry/sentry-go/integrations_test.go
@@ -1,0 +1,226 @@
+package sentry
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestTransformStringsIntoRegexps(t *testing.T) {
+	got := transformStringsIntoRegexps([]string{
+		"+",
+		"foo",
+		"*",
+		"(?i)bar",
+		"[]",
+	})
+
+	want := []*regexp.Regexp{
+		regexp.MustCompile("foo"),
+		regexp.MustCompile("(?i)bar"),
+	}
+
+	assertEqual(t, got, want)
+}
+
+func TestGetIgnoreErrorsSuspectsEmptyEvent(t *testing.T) {
+	event := &Event{}
+	got := getIgnoreErrorsSuspects(event)
+	want := []string{}
+	assertEqual(t, got, want)
+}
+
+func TestGetIgnoreErrorsSuspectsMessage(t *testing.T) {
+	event := &Event{
+		Message: "foo",
+	}
+	got := getIgnoreErrorsSuspects(event)
+	want := []string{"foo"}
+	assertEqual(t, got, want)
+}
+
+func TestGetIgnoreErrorsSuspectsException(t *testing.T) {
+	event := &Event{
+		Exception: []Exception{{
+			Type:  "exType",
+			Value: "exVal",
+		}},
+	}
+	got := getIgnoreErrorsSuspects(event)
+	want := []string{
+		"exType",
+		"exVal",
+	}
+	assertEqual(t, got, want)
+}
+
+func TestGetIgnoreErrorsSuspectsMultipleExceptions(t *testing.T) {
+	event := &Event{
+		Exception: []Exception{{
+			Type:  "exType",
+			Value: "exVal",
+		}, {
+			Type:  "exTypeTwo",
+			Value: "exValTwo",
+		}},
+	}
+	got := getIgnoreErrorsSuspects(event)
+	want := []string{
+		"exType",
+		"exVal",
+		"exTypeTwo",
+		"exValTwo",
+	}
+	assertEqual(t, got, want)
+}
+
+func TestGetIgnoreErrorsSuspectsMessageAndException(t *testing.T) {
+	event := &Event{
+		Message: "foo",
+		Exception: []Exception{{
+			Type:  "exType",
+			Value: "exVal",
+		}},
+	}
+	got := getIgnoreErrorsSuspects(event)
+	want := []string{
+		"foo",
+		"exType",
+		"exVal",
+	}
+	assertEqual(t, got, want)
+}
+
+func TestGetIgnoreErrorsSuspectsMessageAndMultipleExceptions(t *testing.T) {
+	event := &Event{
+		Message: "foo",
+		Exception: []Exception{{
+			Type:  "exType",
+			Value: "exVal",
+		}, {
+			Type:  "exTypeTwo",
+			Value: "exValTwo",
+		}},
+	}
+	got := getIgnoreErrorsSuspects(event)
+	want := []string{
+		"foo",
+		"exType",
+		"exVal",
+		"exTypeTwo",
+		"exValTwo",
+	}
+	assertEqual(t, got, want)
+}
+
+func TestIgnoreErrorsIntegration(t *testing.T) {
+	iei := ignoreErrorsIntegration{
+		ignoreErrors: []*regexp.Regexp{
+			regexp.MustCompile("foo"),
+			regexp.MustCompile("(?i)bar"),
+		},
+	}
+
+	dropped := &Event{
+		Message: "foo",
+	}
+
+	alsoDropped := &Event{
+		Exception: []Exception{{
+			Type: "foo",
+		}},
+	}
+
+	thisDroppedAsWell := &Event{
+		Exception: []Exception{{
+			Value: "Bar",
+		}},
+	}
+
+	notDropped := &Event{
+		Message: "dont",
+	}
+
+	alsoNotDropped := &Event{
+		Exception: []Exception{{
+			Type:  "really",
+			Value: "dont",
+		}},
+	}
+
+	if iei.processor(dropped, &EventHint{}) != nil {
+		t.Error("Event should be dropped")
+	}
+
+	if iei.processor(alsoDropped, &EventHint{}) != nil {
+		t.Error("Event should be dropped")
+	}
+
+	if iei.processor(thisDroppedAsWell, &EventHint{}) != nil {
+		t.Error("Event should be dropped")
+	}
+
+	if iei.processor(notDropped, &EventHint{}) == nil {
+		t.Error("Event should not be dropped")
+	}
+
+	if iei.processor(alsoNotDropped, &EventHint{}) == nil {
+		t.Error("Event should not be dropped")
+	}
+}
+
+func TestContextifyFrames(t *testing.T) {
+	cfi := contextifyFramesIntegration{
+		sr:              newSourceReader(),
+		contextLines:    5,
+		cachedLocations: make(map[string]string),
+	}
+
+	stacktrace := Trace()
+
+	frame := cfi.contextify(stacktrace.Frames)[len(stacktrace.Frames)-1]
+
+	assertEqual(t, frame.PreContext, []string{
+		")",
+		"",
+		"// NOTE: if you modify this file, you are also responsible for updating LoC position in Stacktrace tests",
+		"",
+		"func Trace() *Stacktrace {",
+	})
+	assertEqual(t, frame.ContextLine, "\treturn NewStacktrace()")
+	assertEqual(t, frame.PostContext, []string{
+		"}",
+		"",
+		"func RedPkgErrorsRanger() error {",
+		"\treturn BluePkgErrorsRanger()",
+		"}",
+	})
+}
+
+func TestContextifyFramesNonexistingFilesShouldNotDropFrames(t *testing.T) {
+	cfi := contextifyFramesIntegration{
+		sr:              newSourceReader(),
+		contextLines:    5,
+		cachedLocations: make(map[string]string),
+	}
+
+	frames := []Frame{{
+		InApp:    true,
+		Function: "fnName",
+		Module:   "same",
+		Filename: "wat.go",
+		AbsPath:  "this/doesnt/exist/wat.go",
+		Lineno:   1,
+		Colno:    2,
+	}, {
+		InApp:    false,
+		Function: "fnNameFoo",
+		Module:   "sameFoo",
+		Filename: "foo.go",
+		AbsPath:  "this/doesnt/exist/foo.go",
+		Lineno:   3,
+		Colno:    5,
+	}}
+
+	contextifiedFrames := cfi.contextify(frames)
+	assertEqual(t, len(contextifiedFrames), len(frames))
+}

--- a/vendor/github.com/getsentry/sentry-go/interfaces.go
+++ b/vendor/github.com/getsentry/sentry-go/interfaces.go
@@ -1,0 +1,180 @@
+package sentry
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Protocol Docs (kinda)
+// https://github.com/getsentry/rust-sentry-types/blob/master/src/protocol/v7.rs
+
+// Level marks the severity of the event
+type Level string
+
+const (
+	LevelDebug   Level = "debug"
+	LevelInfo    Level = "info"
+	LevelWarning Level = "warning"
+	LevelError   Level = "error"
+	LevelFatal   Level = "fatal"
+)
+
+// https://docs.sentry.io/development/sdk-dev/interfaces/sdk/
+type SdkInfo struct {
+	Name         string       `json:"name,omitempty"`
+	Version      string       `json:"version,omitempty"`
+	Integrations []string     `json:"integrations,omitempty"`
+	Packages     []SdkPackage `json:"packages,omitempty"`
+}
+
+type SdkPackage struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// TODO: This type could be more useful, as map of interface{} is too generic
+// and requires a lot of type assertions in beforeBreadcrumb calls
+// plus it could just be `map[string]interface{}` then
+type BreadcrumbHint map[string]interface{}
+
+// https://docs.sentry.io/development/sdk-dev/interfaces/breadcrumbs/
+type Breadcrumb struct {
+	Category  string                 `json:"category,omitempty"`
+	Data      map[string]interface{} `json:"data,omitempty"`
+	Level     Level                  `json:"level,omitempty"`
+	Message   string                 `json:"message,omitempty"`
+	Timestamp int64                  `json:"timestamp,omitempty"`
+	Type      string                 `json:"type,omitempty"`
+}
+
+// https://docs.sentry.io/development/sdk-dev/interfaces/user/
+type User struct {
+	Email     string `json:"email,omitempty"`
+	ID        string `json:"id,omitempty"`
+	IPAddress string `json:"ip_address,omitempty"`
+	Username  string `json:"username,omitempty"`
+}
+
+// https://docs.sentry.io/development/sdk-dev/interfaces/http/
+type Request struct {
+	URL         string            `json:"url,omitempty"`
+	Method      string            `json:"method,omitempty"`
+	Data        string            `json:"data,omitempty"`
+	QueryString string            `json:"query_string,omitempty"`
+	Cookies     string            `json:"cookies,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
+}
+
+func (r Request) FromHTTPRequest(request *http.Request) Request {
+	// Method
+	r.Method = request.Method
+
+	// URL
+	protocol := schemeHTTP
+	if request.TLS != nil || request.Header.Get("X-Forwarded-Proto") == "https" {
+		protocol = schemeHTTPS
+	}
+	r.URL = fmt.Sprintf("%s://%s%s", protocol, request.Host, request.URL.Path)
+
+	// Headers
+	headers := make(map[string]string, len(request.Header))
+	for k, v := range request.Header {
+		headers[k] = strings.Join(v, ",")
+	}
+	headers["Host"] = request.Host
+	r.Headers = headers
+
+	// Cookies
+	r.Cookies = request.Header.Get("Cookie")
+
+	// Env
+	if addr, port, err := net.SplitHostPort(request.RemoteAddr); err == nil {
+		r.Env = map[string]string{"REMOTE_ADDR": addr, "REMOTE_PORT": port}
+	}
+
+	// QueryString
+	r.QueryString = request.URL.RawQuery
+
+	// Body
+	if request.GetBody != nil {
+		if bodyCopy, err := request.GetBody(); err == nil && bodyCopy != nil {
+			body, err := ioutil.ReadAll(bodyCopy)
+			if err == nil {
+				r.Data = string(body)
+			}
+		}
+	}
+
+	return r
+}
+
+// https://docs.sentry.io/development/sdk-dev/interfaces/exception/
+type Exception struct {
+	Type          string      `json:"type,omitempty"`
+	Value         string      `json:"value,omitempty"`
+	Module        string      `json:"module,omitempty"`
+	Stacktrace    *Stacktrace `json:"stacktrace,omitempty"`
+	RawStacktrace *Stacktrace `json:"raw_stacktrace,omitempty"`
+}
+
+type EventID string
+
+// https://docs.sentry.io/development/sdk-dev/attributes/
+type Event struct {
+	Breadcrumbs []*Breadcrumb          `json:"breadcrumbs,omitempty"`
+	Contexts    map[string]interface{} `json:"contexts,omitempty"`
+	Dist        string                 `json:"dist,omitempty"`
+	Environment string                 `json:"environment,omitempty"`
+	EventID     EventID                `json:"event_id,omitempty"`
+	Extra       map[string]interface{} `json:"extra,omitempty"`
+	Fingerprint []string               `json:"fingerprint,omitempty"`
+	Level       Level                  `json:"level,omitempty"`
+	Message     string                 `json:"message,omitempty"`
+	Platform    string                 `json:"platform,omitempty"`
+	Release     string                 `json:"release,omitempty"`
+	Sdk         SdkInfo                `json:"sdk,omitempty"`
+	ServerName  string                 `json:"server_name,omitempty"`
+	Threads     []Thread               `json:"threads,omitempty"`
+	Tags        map[string]string      `json:"tags,omitempty"`
+	Timestamp   int64                  `json:"timestamp,omitempty"`
+	Transaction string                 `json:"transaction,omitempty"`
+	User        User                   `json:"user,omitempty"`
+	Logger      string                 `json:"logger,omitempty"`
+	Modules     map[string]string      `json:"modules,omitempty"`
+	Request     Request                `json:"request,omitempty"`
+	Exception   []Exception            `json:"exception,omitempty"`
+}
+
+func NewEvent() *Event {
+	event := Event{
+		Contexts: make(map[string]interface{}),
+		Extra:    make(map[string]interface{}),
+		Tags:     make(map[string]string),
+		Modules:  make(map[string]string),
+	}
+	return &event
+}
+
+type Thread struct {
+	ID            string      `json:"id,omitempty"`
+	Name          string      `json:"name,omitempty"`
+	Stacktrace    *Stacktrace `json:"stacktrace,omitempty"`
+	RawStacktrace *Stacktrace `json:"raw_stacktrace,omitempty"`
+	Crashed       bool        `json:"crashed,omitempty"`
+	Current       bool        `json:"current,omitempty"`
+}
+
+type EventHint struct {
+	Data               interface{}
+	EventID            string
+	OriginalException  error
+	RecoveredException interface{}
+	Context            context.Context
+	Request            *http.Request
+	Response           *http.Response
+}

--- a/vendor/github.com/getsentry/sentry-go/iris/README.md
+++ b/vendor/github.com/getsentry/sentry-go/iris/README.md
@@ -1,0 +1,125 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry Iris Handler for Sentry-go SDK
+
+**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/iris
+
+**Example:** https://github.com/getsentry/sentry-go/tree/master/example/iris
+
+## Installation
+
+```sh
+go get github.com/getsentry/sentry-go/iris
+```
+
+```go
+import (
+    "fmt"
+
+    "github.com/getsentry/sentry-go"
+    sentryiris "github.com/getsentry/sentry-go/iris"
+    "github.com/kataras/iris"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+}); err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+}
+
+// Then create your app
+app := iris.Default()
+
+// Once it's done, you can attach the handler as one of your middleware
+app.Use(sentryiris.New(sentryiris.Options{}))
+
+// Set up routes
+app.Get("/", func(ctx iris.Context) {
+    ctx.Writef"Hello world!")
+})
+
+// And run it
+app.Run(iris.Addr(":3000"))
+```
+
+## Configuration
+
+`sentryiris` accepts a struct of `Options` that allows you to configure how the handler will behave.
+
+Currently it respects 3 options:
+
+```go
+// Whether Sentry should repanic after recovery, in most cases it should be set to true,
+// as iris.Default includes its own Recovery middleware that handles http responses.
+Repanic         bool
+// Whether you want to block the request before moving forward with the response.
+// Because Iris's default `Recovery` handler doesn't restart the application,
+// it's safe to either skip this option or set it to `false`.
+WaitForDelivery bool
+// Timeout for the event delivery requests.
+Timeout         time.Duration
+```
+
+## Usage
+
+`sentryiris` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the `iris.Context`, which makes it available throughout the rest of the request's lifetime.
+You can access it by using the `sentryiris.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
+And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
+
+**Keep in mind that `*sentry.Hub` won't be available in middleware attached before to `sentryiris`!**
+
+```go
+app := iris.Default()
+
+app.Use(sentryiris.New(sentryiris.Options{
+    Repanic: true,
+}))
+
+app.Use(func(ctx iris.Context) {
+    if hub := sentryiris.GetHubFromContext(ctx); hub != nil {
+        hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+    }
+    ctx.Next()
+})
+
+app.Get("/", func(ctx iris.Context) {
+    if hub := sentryiris.GetHubFromContext(ctx); hub != nil {
+        hub.WithScope(func(scope *sentry.Scope) {
+            scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+            hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+        })
+    }
+    ctx.StatusCode(http.StatusOK)
+})
+
+app.Get("/foo", func(ctx iris.Context) {
+    // sentryiris handler will catch it just fine. Also, because we attached "someRandomTag"
+    // in the middleware before, it will be sent through as well
+    panic("y tho")
+})
+
+app.Run(iris.Addr(":3000"))
+```
+
+### Accessing Request in `BeforeSend` callback
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+    BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+        if hint.Context != nil {
+            if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+                // You have access to the original Request here
+            }
+        }
+
+        return event
+    },
+})
+```

--- a/vendor/github.com/getsentry/sentry-go/iris/sentryiris.go
+++ b/vendor/github.com/getsentry/sentry-go/iris/sentryiris.go
@@ -1,0 +1,81 @@
+package sentryiris
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/kataras/iris"
+)
+
+const valuesKey = "sentry"
+
+type handler struct {
+	repanic         bool
+	waitForDelivery bool
+	timeout         time.Duration
+}
+
+type Options struct {
+	// Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
+	// as iris.Default includes it's own Recovery middleware what handles http responses.
+	Repanic bool
+	// WaitForDelivery configures whether you want to block the request before moving forward with the response.
+	// Because Iris's default `Recovery` handler doesn't restart the application,
+	// it's safe to either skip this option or set it to `false`.
+	WaitForDelivery bool
+	// Timeout for the event delivery requests.
+	Timeout time.Duration
+}
+
+// New returns a function that satisfies iris.Handler interface
+// It can be used with Use() method.
+func New(options Options) iris.Handler {
+	handler := handler{
+		repanic:         false,
+		timeout:         time.Second * 2,
+		waitForDelivery: false,
+	}
+
+	if options.Repanic {
+		handler.repanic = true
+	}
+
+	if options.WaitForDelivery {
+		handler.waitForDelivery = true
+	}
+
+	return handler.handle
+}
+
+func (h *handler) handle(ctx iris.Context) {
+	hub := sentry.CurrentHub().Clone()
+	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(ctx.Request()))
+	ctx.Values().Set(valuesKey, hub)
+	defer h.recoverWithSentry(hub, ctx.Request())
+	ctx.Next()
+}
+
+func (h *handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
+	if err := recover(); err != nil {
+		eventID := hub.RecoverWithContext(
+			context.WithValue(r.Context(), sentry.RequestContextKey, r),
+			err,
+		)
+		if eventID != nil && h.waitForDelivery {
+			hub.Flush(h.timeout)
+		}
+		if h.repanic {
+			panic(err)
+		}
+	}
+}
+
+// GetHubFromContext retrieves attached *sentry.Hub instance from iris.Context.
+func GetHubFromContext(ctx iris.Context) *sentry.Hub {
+	if hub, ok := ctx.Values().Get(valuesKey).(*sentry.Hub); ok {
+		return hub
+	}
+	return nil
+}

--- a/vendor/github.com/getsentry/sentry-go/martini/README.md
+++ b/vendor/github.com/getsentry/sentry-go/martini/README.md
@@ -1,0 +1,122 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry Martini Handler for Sentry-go SDK
+
+**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/martini
+
+**Example:** https://github.com/getsentry/sentry-go/tree/master/example/martini
+
+## Installation
+
+```sh
+go get github.com/getsentry/sentry-go/martini
+```
+
+```go
+import (
+    "fmt"
+
+    "github.com/getsentry/sentry-go"
+    sentrymartini "github.com/getsentry/sentry-go/martini"
+    "github.com/go-martini/martini"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+}); err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+}
+
+// Then create your app
+app := martini.Classic()
+
+// Once it's done, you can attach the handler as one of your middleware
+app.Use(sentrymartini.New(sentrymartini.Options{}))
+
+// Set up routes
+app.Get("/", func() string {
+    return "Hello world!"
+})
+
+// And run it
+app.Run()
+```
+
+## Configuration
+
+`sentrymartini` accepts a struct of `Options` that allows you to configure how the handler will behave.
+
+Currently it respects 3 options:
+
+```go
+// Whether Sentry should repanic after recovery, in most cases it should be set to true,
+// as martini.Classic includes its own Recovery middleware that handles http responses.
+Repanic         bool
+// Whether you want to block the request before moving forward with the response.
+// Because Martini's default `Recovery` handler doesn't restart the application,
+// it's safe to either skip this option or set it to `false`.
+WaitForDelivery bool
+// Timeout for the event delivery requests.
+Timeout         time.Duration
+```
+
+## Usage
+
+`sentrymartini` maps an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) as one of the services available throughout the rest of the request's lifetime.
+You can access it through providing a `hub *sentry.Hub` parameter in any of your proceeding middleware and routes.
+And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
+
+**Keep in mind that `*sentry.Hub` won't be available in middleware attached before to `sentrymartini`!**
+
+```go
+app := martini.Classic()
+
+app.Use(sentrymartini.New(sentrymartini.Options{
+    Repanic: true,
+}))
+
+app.Use(func(rw http.ResponseWriter, r *http.Request, c martini.Context, hub *sentry.Hub) {
+    hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+})
+
+app.Get("/", func(rw http.ResponseWriter, r *http.Request, hub *sentry.Hub) {
+    if someCondition {
+        hub.WithScope(func (scope *sentry.Scope) {
+            scope.SetExtra("unwantedQuery", rw.URL.RawQuery)
+            hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+        })
+    }
+    rw.WriteHeader(http.StatusOK)
+})
+
+app.Get("/foo", func() string {
+    // sentrymartini handler will catch it just fine. Also, because we attached "someRandomTag"
+    // in the middleware before, it will be sent through as well
+    panic("y tho")
+})
+
+app.Run()
+```
+
+### Accessing Request in `BeforeSend` callback
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+    BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+        if hint.Context != nil {
+            if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+                // You have access to the original Request here
+            }
+        }
+
+        return event
+    },
+})
+```

--- a/vendor/github.com/getsentry/sentry-go/martini/sentrymartini.go
+++ b/vendor/github.com/getsentry/sentry-go/martini/sentrymartini.go
@@ -1,0 +1,71 @@
+package sentrymartini
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/go-martini/martini"
+)
+
+type handler struct {
+	repanic         bool
+	waitForDelivery bool
+	timeout         time.Duration
+}
+
+type Options struct {
+	// Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
+	// as martini.Classic includes it's own Recovery middleware what handles http responses.
+	Repanic bool
+	// WaitForDelivery configures whether you want to block the request before moving forward with the response.
+	// Because Martini's default `Recovery` handler doesn't restart the application,
+	// it's safe to either skip this option or set it to `false`.
+	WaitForDelivery bool
+	// Timeout for the event delivery requests.
+	Timeout time.Duration
+}
+
+// New returns a function that satisfies martini.Handler interface
+// It can be used with Use() or Handlers() methods.
+func New(options Options) martini.Handler {
+	handler := handler{
+		repanic:         false,
+		timeout:         time.Second * 2,
+		waitForDelivery: false,
+	}
+
+	if options.Repanic {
+		handler.repanic = true
+	}
+
+	if options.WaitForDelivery {
+		handler.waitForDelivery = true
+	}
+
+	return handler.handle
+}
+
+func (h *handler) handle(rw http.ResponseWriter, r *http.Request, ctx martini.Context) {
+	hub := sentry.CurrentHub().Clone()
+	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+	ctx.Map(hub)
+	defer h.recoverWithSentry(hub, r)
+	ctx.Next()
+}
+
+func (h *handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
+	if err := recover(); err != nil {
+		eventID := hub.RecoverWithContext(
+			context.WithValue(r.Context(), sentry.RequestContextKey, r),
+			err,
+		)
+		if eventID != nil && h.waitForDelivery {
+			hub.Flush(h.timeout)
+		}
+		if h.repanic {
+			panic(err)
+		}
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/mocks_test.go
+++ b/vendor/github.com/getsentry/sentry-go/mocks_test.go
@@ -1,0 +1,33 @@
+package sentry
+
+import (
+	"time"
+)
+
+type ScopeMock struct {
+	breadcrumb      *Breadcrumb
+	shouldDropEvent bool
+}
+
+func (scope *ScopeMock) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
+	scope.breadcrumb = breadcrumb
+}
+
+func (scope *ScopeMock) ApplyToEvent(event *Event, hint *EventHint) *Event {
+	if scope.shouldDropEvent {
+		return nil
+	}
+	return event
+}
+
+type TransportMock struct {
+	lastEvent *Event
+}
+
+func (t *TransportMock) Configure(options ClientOptions) {}
+func (t *TransportMock) SendEvent(event *Event) {
+	t.lastEvent = event
+}
+func (t *TransportMock) Flush(timeout time.Duration) bool {
+	return true
+}

--- a/vendor/github.com/getsentry/sentry-go/negroni/README.md
+++ b/vendor/github.com/getsentry/sentry-go/negroni/README.md
@@ -1,0 +1,159 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry Negroni Handler for Sentry-go SDK
+
+**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/negroni
+
+**Example:** https://github.com/getsentry/sentry-go/tree/master/example/negroni
+
+## Installation
+
+```sh
+go get github.com/getsentry/sentry-go/negroni
+```
+
+```go
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/getsentry/sentry-go"
+    sentrynegroni "github.com/getsentry/sentry-go/negroni"
+    "github.com/urfave/negroni"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+}); err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+}
+
+// Then create your app
+app := negroni.Classic()
+
+// Once it's done, you can attach the handler as one of your middleware
+app.Use(sentrynegroni.New(sentrynegroni.Options{}))
+
+// Set up routes
+mux := http.NewServeMux()
+
+mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "Hello world!")
+})
+
+app.UseHandler(mux)
+
+// And run it
+http.ListenAndServe(":3000", app)
+```
+
+## Configuration
+
+`sentrynegroni` accepts a struct of `Options` that allows you to configure how the handler will behave.
+
+Currently it respects 3 options:
+
+```go
+// Whether Sentry should repanic after recovery, in most cases it should be set to true,
+// as negroni.Classic includes its own Recovery middleware that handles http responses.
+Repanic         bool
+// Whether you want to block the request before moving forward with the response.
+// Because Negroni's default `Recovery` handler doesn't restart the application,
+// it's safe to either skip this option or set it to `false`.
+WaitForDelivery bool
+// Timeout for the event delivery requests.
+Timeout         time.Duration
+```
+
+## Usage
+
+`sentrynegroni` attaches an instance of `*sentry.Hub` (https://godoc.org/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
+You can access it by using the `sentry.GetHubFromContext()` method on the request itself in any of your proceeding middleware and routes.
+And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
+
+**Keep in mind that `*sentry.Hub` won't be available in middleware attached before to `sentrynegroni`!**
+
+```go
+app := negroni.Classic()
+
+app.Use(sentrynegroni.New(sentrynegroni.Options{
+    Repanic: true,
+}))
+
+app.Use(negroni.HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+    hub := sentry.GetHubFromContext(r.Context())
+    hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+    next(rw, r)
+}))
+
+mux := http.NewServeMux()
+
+mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+    hub := sentry.GetHubFromContext(r.Context())
+    hub.WithScope(func(scope *sentry.Scope) {
+        scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
+        hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+    })
+    rw.WriteHeader(http.StatusOK)
+})
+
+mux.HandleFunc("/foo", func(rw http.ResponseWriter, r *http.Request) {
+    // sentrynagroni handler will catch it just fine. Also, because we attached "someRandomTag"
+    // in the middleware before, it will be sent through as well
+    panic("y tho")
+})
+
+app.UseHandler(mux)
+
+http.ListenAndServe(":3000", app)
+```
+
+### Accessing Request in `BeforeSend` callback
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+    BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+        if hint.Context != nil {
+            if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+                // You have access to the original Request here
+            }
+        }
+
+        return event
+    },
+})
+```
+
+## Using Negroni's `PanicHandlerFunc` Option
+
+Negroni provides an option called `PanicHandlerFunc`, which lets you "plug-in" to its default `Recovery` middleware.
+
+`sentrynegroni` exports a very barebones implementation, which utilizes it, so if you don't need anything else than just reporting panics to Sentry,
+you can use it instead, as it's just one line of code!
+
+You can still use `BeforeSend` and event processors to modify data before delivering it to Sentry, using this method as well.
+
+```go
+app := negroni.New()
+
+recovery := negroni.NewRecovery()
+recovery.PanicHandlerFunc = sentrynegroni.PanicHandlerFunc
+
+app.Use(recovery)
+
+mux := http.NewServeMux()
+mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+    panic("y tho")
+})
+
+app.UseHandler(mux)
+
+http.ListenAndServe(":3000", app)
+```

--- a/vendor/github.com/getsentry/sentry-go/negroni/sentrynegroni.go
+++ b/vendor/github.com/getsentry/sentry-go/negroni/sentrynegroni.go
@@ -1,0 +1,87 @@
+package sentrynegroni
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/urfave/negroni"
+)
+
+type handler struct {
+	repanic         bool
+	waitForDelivery bool
+	timeout         time.Duration
+}
+
+type Options struct {
+	// Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
+	// as negroni.Classic includes it's own Recovery middleware what handles http responses.
+	Repanic bool
+	// WaitForDelivery configures whether you want to block the request before moving forward with the response.
+	// Because Negroni's default `Recovery` handler doesn't restart the application,
+	// it's safe to either skip this option or set it to `false`.
+	WaitForDelivery bool
+	// Timeout for the event delivery requests.
+	Timeout time.Duration
+}
+
+// New returns a handler struct which satisfies Negroni's middleware interface
+// It can be used with New(), Use() or With() methods.
+func New(options Options) negroni.Handler {
+	handler := handler{
+		repanic:         false,
+		timeout:         time.Second * 2,
+		waitForDelivery: false,
+	}
+
+	if options.Repanic {
+		handler.repanic = true
+	}
+
+	if options.WaitForDelivery {
+		handler.waitForDelivery = true
+	}
+
+	return &handler
+}
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	hub := sentry.CurrentHub().Clone()
+	hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
+	ctx := sentry.SetHubOnContext(
+		context.WithValue(r.Context(), sentry.RequestContextKey, r),
+		hub,
+	)
+	defer h.recoverWithSentry(hub, r)
+	next(rw, r.WithContext(ctx))
+}
+
+func (h *handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
+	if err := recover(); err != nil {
+		eventID := hub.RecoverWithContext(
+			context.WithValue(r.Context(), sentry.RequestContextKey, r),
+			err,
+		)
+		if eventID != nil && h.waitForDelivery {
+			hub.Flush(h.timeout)
+		}
+		if h.repanic {
+			panic(err)
+		}
+	}
+}
+
+// PanicHandlerFunc can be used for Negroni's default Recovery middleware option called `PanicHandlerFunc`,
+// which let you "plug-in" to it's own handler.
+func PanicHandlerFunc(info *negroni.PanicInformation) {
+	hub := sentry.CurrentHub().Clone()
+	hub.WithScope(func(scope *sentry.Scope) {
+		scope.SetRequest(sentry.Request{}.FromHTTPRequest(info.Request))
+		hub.RecoverWithContext(
+			context.WithValue(context.Background(), sentry.RequestContextKey, info.Request),
+			info.RecoveredPanic,
+		)
+	})
+}

--- a/vendor/github.com/getsentry/sentry-go/scope.go
+++ b/vendor/github.com/getsentry/sentry-go/scope.go
@@ -1,0 +1,238 @@
+package sentry
+
+import (
+	"reflect"
+	"time"
+)
+
+// Scope holds contextual data for the current scope.
+//
+// The scope is an object that can cloned efficiently and stores data that
+// is locally relevant to an event.  For instance the scope will hold recorded
+// breadcrumbs and similar information.
+//
+// The scope can be interacted with in two ways:
+//
+// 1. the scope is routinely updated with information by functions such as
+//    `AddBreadcrumb` which will modify the currently top-most scope.
+// 2. the topmost scope can also be configured through the `ConfigureScope`
+//    method.
+//
+// Note that the scope can only be modified but not inspected.
+// Only the client can use the scope to extract information currently.
+type Scope struct {
+	breadcrumbs     []*Breadcrumb
+	user            User
+	tags            map[string]string
+	contexts        map[string]interface{}
+	extra           map[string]interface{}
+	fingerprint     []string
+	level           Level
+	request         Request
+	eventProcessors []EventProcessor
+}
+
+func NewScope() *Scope {
+	scope := Scope{
+		breadcrumbs: make([]*Breadcrumb, 0),
+		tags:        make(map[string]string),
+		contexts:    make(map[string]interface{}),
+		extra:       make(map[string]interface{}),
+		fingerprint: make([]string, 0),
+	}
+
+	return &scope
+}
+
+// AddBreadcrumb adds new breadcrumb to the current scope
+// and optionaly throws the old one if limit is reached.
+func (scope *Scope) AddBreadcrumb(breadcrumb *Breadcrumb, limit int) {
+	if breadcrumb.Timestamp == 0 {
+		breadcrumb.Timestamp = time.Now().Unix()
+	}
+
+	breadcrumbs := append(scope.breadcrumbs, breadcrumb)
+	if len(breadcrumbs) > limit {
+		scope.breadcrumbs = breadcrumbs[1 : limit+1]
+	} else {
+		scope.breadcrumbs = breadcrumbs
+	}
+}
+
+// ClearBreadcrumbs clears all breadcrumbs from the current scope.
+func (scope *Scope) ClearBreadcrumbs() {
+	scope.breadcrumbs = []*Breadcrumb{}
+}
+
+// SetUser sets new user for the current scope.
+func (scope *Scope) SetUser(user User) {
+	scope.user = user
+}
+
+// SetRequest sets new user for the current scope.
+func (scope *Scope) SetRequest(request Request) {
+	scope.request = request
+}
+
+// SetTag adds a tag to the current scope.
+func (scope *Scope) SetTag(key, value string) {
+	scope.tags[key] = value
+}
+
+// SetTags assigns multiple tags to the current scope.
+func (scope *Scope) SetTags(tags map[string]string) {
+	for k, v := range tags {
+		scope.tags[k] = v
+	}
+}
+
+// RemoveTag removes a tag from the current scope.
+func (scope *Scope) RemoveTag(key string) {
+	delete(scope.tags, key)
+}
+
+// SetContext adds a context to the current scope.
+func (scope *Scope) SetContext(key string, value interface{}) {
+	scope.contexts[key] = value
+}
+
+// SetContexts assigns multiple contexts to the current scope.
+func (scope *Scope) SetContexts(contexts map[string]interface{}) {
+	for k, v := range contexts {
+		scope.contexts[k] = v
+	}
+}
+
+// RemoveContext removes a context from the current scope.
+func (scope *Scope) RemoveContext(key string) {
+	delete(scope.contexts, key)
+}
+
+// SetExtra adds an extra to the current scope.
+func (scope *Scope) SetExtra(key string, value interface{}) {
+	scope.extra[key] = value
+}
+
+// SetExtras assigns multiple extras to the current scope.
+func (scope *Scope) SetExtras(extra map[string]interface{}) {
+	for k, v := range extra {
+		scope.extra[k] = v
+	}
+}
+
+// RemoveExtra removes a extra from the current scope.
+func (scope *Scope) RemoveExtra(key string) {
+	delete(scope.extra, key)
+}
+
+// SetFingerprint sets new fingerprint for the current scope.
+func (scope *Scope) SetFingerprint(fingerprint []string) {
+	scope.fingerprint = fingerprint
+}
+
+// SetLevel sets new level for the current scope.
+func (scope *Scope) SetLevel(level Level) {
+	scope.level = level
+}
+
+// Clone returns a copy of the current scope with all data copied over.
+func (scope *Scope) Clone() *Scope {
+	clone := NewScope()
+	clone.user = scope.user
+	clone.breadcrumbs = make([]*Breadcrumb, len(scope.breadcrumbs))
+	copy(clone.breadcrumbs, scope.breadcrumbs)
+	for key, value := range scope.tags {
+		clone.tags[key] = value
+	}
+	for key, value := range scope.contexts {
+		clone.contexts[key] = value
+	}
+	for key, value := range scope.extra {
+		clone.extra[key] = value
+	}
+	clone.fingerprint = make([]string, len(scope.fingerprint))
+	copy(clone.fingerprint, scope.fingerprint)
+	clone.level = scope.level
+	clone.request = scope.request
+	return clone
+}
+
+// Clear removed the data from the current scope.
+func (scope *Scope) Clear() {
+	*scope = *NewScope()
+}
+
+// AddEventProcessor adds an event processor to the current scope.
+func (scope *Scope) AddEventProcessor(processor EventProcessor) {
+	scope.eventProcessors = append(scope.eventProcessors, processor)
+}
+
+// ApplyToEvent takes the data from the current scope and attaches it to the event.
+func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint) *Event {
+	if len(scope.breadcrumbs) > 0 {
+		if event.Breadcrumbs == nil {
+			event.Breadcrumbs = []*Breadcrumb{}
+		}
+
+		event.Breadcrumbs = append(event.Breadcrumbs, scope.breadcrumbs...)
+	}
+
+	if len(scope.tags) > 0 {
+		if event.Tags == nil {
+			event.Tags = make(map[string]string)
+		}
+
+		for key, value := range scope.tags {
+			event.Tags[key] = value
+		}
+	}
+
+	if len(scope.contexts) > 0 {
+		if event.Contexts == nil {
+			event.Contexts = make(map[string]interface{})
+		}
+
+		for key, value := range scope.contexts {
+			event.Contexts[key] = value
+		}
+	}
+
+	if len(scope.extra) > 0 {
+		if event.Extra == nil {
+			event.Extra = make(map[string]interface{})
+		}
+
+		for key, value := range scope.extra {
+			event.Extra[key] = value
+		}
+	}
+
+	if (reflect.DeepEqual(event.User, User{})) {
+		event.User = scope.user
+	}
+
+	if (event.Fingerprint == nil || len(event.Fingerprint) == 0) &&
+		len(scope.fingerprint) > 0 {
+		event.Fingerprint = make([]string, len(scope.fingerprint))
+		copy(event.Fingerprint, scope.fingerprint)
+	}
+
+	if scope.level != "" {
+		event.Level = scope.level
+	}
+
+	if (reflect.DeepEqual(event.Request, Request{})) {
+		event.Request = scope.request
+	}
+
+	for _, processor := range scope.eventProcessors {
+		id := event.EventID
+		event = processor(event, hint)
+		if event == nil {
+			Logger.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
+			return nil
+		}
+	}
+
+	return event
+}

--- a/vendor/github.com/getsentry/sentry-go/scope_test.go
+++ b/vendor/github.com/getsentry/sentry-go/scope_test.go
@@ -1,0 +1,581 @@
+package sentry
+
+import (
+	"testing"
+	"time"
+)
+
+func fillScopeWithData(scope *Scope) *Scope {
+	scope.breadcrumbs = []*Breadcrumb{{Timestamp: 1337, Message: "scopeBreadcrumbMessage"}}
+	scope.user = User{ID: "1337"}
+	scope.tags = map[string]string{"scopeTagKey": "scopeTagValue"}
+	scope.contexts = map[string]interface{}{"scopeContextsKey": "scopeContextsValue"}
+	scope.extra = map[string]interface{}{"scopeExtraKey": "scopeExtraValue"}
+	scope.fingerprint = []string{"scopeFingerprintOne", "scopeFingerprintTwo"}
+	scope.level = LevelDebug
+	scope.request = Request{URL: "wat"}
+	return scope
+}
+
+func fillEventWithData(event *Event) *Event {
+	event.Breadcrumbs = []*Breadcrumb{{Timestamp: 1337, Message: "eventBreadcrumbMessage"}}
+	event.User = User{ID: "42"}
+	event.Tags = map[string]string{"eventTagKey": "eventTagValue"}
+	event.Contexts = map[string]interface{}{"eventContextsKey": "eventContextsValue"}
+	event.Extra = map[string]interface{}{"eventExtraKey": "eventExtraValue"}
+	event.Fingerprint = []string{"eventFingerprintOne", "eventFingerprintTwo"}
+	event.Level = LevelInfo
+	event.Request = Request{URL: "aye"}
+	return event
+}
+
+func TestScopeSetUser(t *testing.T) {
+	scope := NewScope()
+	scope.SetUser(User{ID: "foo"})
+	assertEqual(t, User{ID: "foo"}, scope.user)
+}
+
+func TestScopeSetUserOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetUser(User{ID: "foo"})
+	scope.SetUser(User{ID: "bar"})
+
+	assertEqual(t, User{ID: "bar"}, scope.user)
+}
+
+func TestScopeSetRequest(t *testing.T) {
+	scope := NewScope()
+	scope.SetRequest(Request{URL: "foo"})
+	assertEqual(t, Request{URL: "foo"}, scope.request)
+}
+
+func TestScopeSetRequestOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetRequest(Request{URL: "foo"})
+	scope.SetRequest(Request{URL: "bar"})
+
+	assertEqual(t, Request{URL: "bar"}, scope.request)
+}
+
+func TestScopeSetTag(t *testing.T) {
+	scope := NewScope()
+	scope.SetTag("a", "foo")
+
+	assertEqual(t, map[string]string{"a": "foo"}, scope.tags)
+}
+
+func TestScopeSetTagMerges(t *testing.T) {
+	scope := NewScope()
+	scope.SetTag("a", "foo")
+	scope.SetTag("b", "bar")
+
+	assertEqual(t, map[string]string{"a": "foo", "b": "bar"}, scope.tags)
+}
+
+func TestScopeSetTagOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetTag("a", "foo")
+	scope.SetTag("a", "bar")
+
+	assertEqual(t, map[string]string{"a": "bar"}, scope.tags)
+}
+
+func TestScopeSetTags(t *testing.T) {
+	scope := NewScope()
+	scope.SetTags(map[string]string{"a": "foo"})
+
+	assertEqual(t, map[string]string{"a": "foo"}, scope.tags)
+}
+
+func TestScopeSetTagsMerges(t *testing.T) {
+	scope := NewScope()
+	scope.SetTags(map[string]string{"a": "foo"})
+	scope.SetTags(map[string]string{"b": "bar", "c": "baz"})
+
+	assertEqual(t, map[string]string{"a": "foo", "b": "bar", "c": "baz"}, scope.tags)
+}
+
+func TestScopeSetTagsOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetTags(map[string]string{"a": "foo"})
+	scope.SetTags(map[string]string{"a": "bar", "b": "baz"})
+
+	assertEqual(t, map[string]string{"a": "bar", "b": "baz"}, scope.tags)
+}
+
+func TestScopeRemoveTag(t *testing.T) {
+	scope := NewScope()
+	scope.SetTag("a", "foo")
+	scope.SetTag("b", "bar")
+	scope.RemoveTag("b")
+
+	assertEqual(t, map[string]string{"a": "foo"}, scope.tags)
+}
+
+func TestScopeRemoveTagSkipsEmptyValues(t *testing.T) {
+	scope := NewScope()
+	scope.SetTag("a", "foo")
+	scope.RemoveTag("b")
+
+	assertEqual(t, map[string]string{"a": "foo"}, scope.tags)
+}
+
+func TestScopeRemoveTagOnEmptyScope(t *testing.T) {
+	scope := NewScope()
+	scope.RemoveTag("b")
+
+	assertEqual(t, make(map[string]string), scope.tags)
+}
+
+func TestScopeSetContext(t *testing.T) {
+	scope := NewScope()
+	scope.SetContext("a", 1)
+
+	assertEqual(t, map[string]interface{}{"a": 1}, scope.contexts)
+}
+
+func TestScopeSetContextMerges(t *testing.T) {
+	scope := NewScope()
+	scope.SetContext("a", "foo")
+	scope.SetContext("b", 2)
+
+	assertEqual(t, map[string]interface{}{"a": "foo", "b": 2}, scope.contexts)
+}
+
+func TestScopeSetContextOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetContext("a", "foo")
+	scope.SetContext("a", 2)
+
+	assertEqual(t, map[string]interface{}{"a": 2}, scope.contexts)
+}
+
+func TestScopeSetContexts(t *testing.T) {
+	scope := NewScope()
+	scope.SetContexts(map[string]interface{}{"a": 1})
+
+	assertEqual(t, map[string]interface{}{"a": 1}, scope.contexts)
+}
+
+func TestScopeSetContextsMerges(t *testing.T) {
+	scope := NewScope()
+	scope.SetContexts(map[string]interface{}{"a": "foo"})
+	scope.SetContexts(map[string]interface{}{"b": 2, "c": 3})
+
+	assertEqual(t, map[string]interface{}{"a": "foo", "b": 2, "c": 3}, scope.contexts)
+}
+
+func TestScopeSetContextsOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetContexts(map[string]interface{}{"a": "foo"})
+	scope.SetContexts(map[string]interface{}{"a": 2, "b": 3})
+
+	assertEqual(t, map[string]interface{}{"a": 2, "b": 3}, scope.contexts)
+}
+
+func TestScopeRemoveContext(t *testing.T) {
+	scope := NewScope()
+	scope.SetContext("a", "foo")
+	scope.SetContext("b", "bar")
+	scope.RemoveContext("b")
+
+	assertEqual(t, map[string]interface{}{"a": "foo"}, scope.contexts)
+}
+
+func TestScopeRemoveContextSkipsEmptyValues(t *testing.T) {
+	scope := NewScope()
+	scope.SetContext("a", "foo")
+	scope.RemoveContext("b")
+
+	assertEqual(t, map[string]interface{}{"a": "foo"}, scope.contexts)
+}
+
+func TestScopeRemoveContextOnEmptyScope(t *testing.T) {
+	scope := NewScope()
+	scope.RemoveContext("b")
+
+	assertEqual(t, make(map[string]interface{}), scope.contexts)
+}
+
+func TestScopeSetExtra(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtra("a", 1)
+
+	assertEqual(t, map[string]interface{}{"a": 1}, scope.extra)
+}
+
+func TestScopeSetExtraMerges(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtra("a", "foo")
+	scope.SetExtra("b", 2)
+
+	assertEqual(t, map[string]interface{}{"a": "foo", "b": 2}, scope.extra)
+}
+
+func TestScopeSetExtraOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtra("a", "foo")
+	scope.SetExtra("a", 2)
+
+	assertEqual(t, map[string]interface{}{"a": 2}, scope.extra)
+}
+
+func TestScopeSetExtras(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtras(map[string]interface{}{"a": 1})
+
+	assertEqual(t, map[string]interface{}{"a": 1}, scope.extra)
+}
+
+func TestScopeSetExtrasMerges(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtras(map[string]interface{}{"a": "foo"})
+	scope.SetExtras(map[string]interface{}{"b": 2, "c": 3})
+
+	assertEqual(t, map[string]interface{}{"a": "foo", "b": 2, "c": 3}, scope.extra)
+}
+
+func TestScopeSetExtrasOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtras(map[string]interface{}{"a": "foo"})
+	scope.SetExtras(map[string]interface{}{"a": 2, "b": 3})
+
+	assertEqual(t, map[string]interface{}{"a": 2, "b": 3}, scope.extra)
+}
+
+func TestScopeRemoveExtra(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtra("a", "foo")
+	scope.SetExtra("b", "bar")
+	scope.RemoveExtra("b")
+
+	assertEqual(t, map[string]interface{}{"a": "foo"}, scope.extra)
+}
+
+func TestScopeRemoveExtraSkipsEmptyValues(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtra("a", "foo")
+	scope.RemoveExtra("b")
+
+	assertEqual(t, map[string]interface{}{"a": "foo"}, scope.extra)
+}
+
+func TestScopeRemoveExtraOnEmptyScope(t *testing.T) {
+	scope := NewScope()
+	scope.RemoveExtra("b")
+
+	assertEqual(t, make(map[string]interface{}), scope.contexts)
+}
+
+func TestScopeSetFingerprint(t *testing.T) {
+	scope := NewScope()
+	scope.SetFingerprint([]string{"abcd"})
+
+	assertEqual(t, []string{"abcd"}, scope.fingerprint)
+}
+
+func TestScopeSetFingerprintOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetFingerprint([]string{"abc"})
+	scope.SetFingerprint([]string{"def"})
+
+	assertEqual(t, []string{"def"}, scope.fingerprint)
+}
+
+func TestScopeSetLevel(t *testing.T) {
+	scope := NewScope()
+	scope.SetLevel(LevelInfo)
+
+	assertEqual(t, scope.level, LevelInfo)
+}
+
+func TestScopeSetLevelOverrides(t *testing.T) {
+	scope := NewScope()
+	scope.SetLevel(LevelInfo)
+	scope.SetLevel(LevelFatal)
+
+	assertEqual(t, scope.level, LevelFatal)
+}
+
+func TestAddBreadcrumbAddsBreadcrumb(t *testing.T) {
+	scope := NewScope()
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "test"}, maxBreadcrumbs)
+	assertEqual(t, []*Breadcrumb{{Timestamp: 1337, Message: "test"}}, scope.breadcrumbs)
+}
+
+func TestAddBreadcrumbAppendsBreadcrumb(t *testing.T) {
+	scope := NewScope()
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "test1"}, maxBreadcrumbs)
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "test2"}, maxBreadcrumbs)
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "test3"}, maxBreadcrumbs)
+
+	assertEqual(t, []*Breadcrumb{
+		{Timestamp: 1337, Message: "test1"},
+		{Timestamp: 1337, Message: "test2"},
+		{Timestamp: 1337, Message: "test3"},
+	}, scope.breadcrumbs)
+}
+
+func TestAddBreadcrumbDefaultLimit(t *testing.T) {
+	scope := NewScope()
+	for i := 0; i < 101; i++ {
+		scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "test"}, maxBreadcrumbs)
+	}
+
+	if len(scope.breadcrumbs) != 100 {
+		t.Error("expected to have only 100 breadcrumbs")
+	}
+}
+
+func TestAddBreadcrumbAddsTimestamp(t *testing.T) {
+	scope := NewScope()
+	before := time.Now().Unix()
+	scope.AddBreadcrumb(&Breadcrumb{Message: "test"}, maxBreadcrumbs)
+	after := time.Now().Unix()
+	ts := scope.breadcrumbs[0].Timestamp
+
+	if ts < before || ts > after {
+		t.Errorf("expected default timestamp to represent current time, was '%d'", ts)
+	}
+}
+
+func TestScopeBasicInheritance(t *testing.T) {
+	scope := NewScope()
+	scope.SetExtra("a", 1)
+	clone := scope.Clone()
+
+	assertEqual(t, scope.extra, clone.extra)
+}
+
+func TestScopeParentChangedInheritance(t *testing.T) {
+	scope := NewScope()
+	clone := scope.Clone()
+
+	clone.SetTag("foo", "bar")
+	clone.SetContext("foo", "bar")
+	clone.SetExtra("foo", "bar")
+	clone.SetLevel(LevelDebug)
+	clone.SetFingerprint([]string{"foo"})
+	clone.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "foo"}, maxBreadcrumbs)
+	clone.SetUser(User{ID: "foo"})
+	clone.SetRequest(Request{URL: "foo"})
+
+	scope.SetTag("foo", "baz")
+	scope.SetContext("foo", "baz")
+	scope.SetExtra("foo", "baz")
+	scope.SetLevel(LevelFatal)
+	scope.SetFingerprint([]string{"bar"})
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "bar"}, maxBreadcrumbs)
+	scope.SetUser(User{ID: "bar"})
+	scope.SetRequest(Request{URL: "bar"})
+
+	assertEqual(t, map[string]string{"foo": "bar"}, clone.tags)
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, clone.contexts)
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, clone.extra)
+	assertEqual(t, LevelDebug, clone.level)
+	assertEqual(t, []string{"foo"}, clone.fingerprint)
+	assertEqual(t, []*Breadcrumb{{Timestamp: 1337, Message: "foo"}}, clone.breadcrumbs)
+	assertEqual(t, User{ID: "foo"}, clone.user)
+	assertEqual(t, Request{URL: "foo"}, clone.request)
+
+	assertEqual(t, map[string]string{"foo": "baz"}, scope.tags)
+	assertEqual(t, map[string]interface{}{"foo": "baz"}, scope.contexts)
+	assertEqual(t, map[string]interface{}{"foo": "baz"}, scope.extra)
+	assertEqual(t, LevelFatal, scope.level)
+	assertEqual(t, []string{"bar"}, scope.fingerprint)
+	assertEqual(t, []*Breadcrumb{{Timestamp: 1337, Message: "bar"}}, scope.breadcrumbs)
+	assertEqual(t, User{ID: "bar"}, scope.user)
+	assertEqual(t, Request{URL: "bar"}, scope.request)
+}
+
+func TestScopeChildOverrideInheritance(t *testing.T) {
+	scope := NewScope()
+
+	scope.SetTag("foo", "baz")
+	scope.SetContext("foo", "baz")
+	scope.SetExtra("foo", "baz")
+	scope.SetLevel(LevelFatal)
+	scope.SetFingerprint([]string{"bar"})
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "bar"}, maxBreadcrumbs)
+	scope.SetUser(User{ID: "bar"})
+	scope.SetRequest(Request{URL: "bar"})
+
+	clone := scope.Clone()
+	clone.SetTag("foo", "bar")
+	clone.SetContext("foo", "bar")
+	clone.SetExtra("foo", "bar")
+	clone.SetLevel(LevelDebug)
+	clone.SetFingerprint([]string{"foo"})
+	clone.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "foo"}, maxBreadcrumbs)
+	clone.SetUser(User{ID: "foo"})
+	clone.SetRequest(Request{URL: "foo"})
+
+	assertEqual(t, map[string]string{"foo": "bar"}, clone.tags)
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, clone.contexts)
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, clone.extra)
+	assertEqual(t, LevelDebug, clone.level)
+	assertEqual(t, []string{"foo"}, clone.fingerprint)
+	assertEqual(t, []*Breadcrumb{
+		{Timestamp: 1337, Message: "bar"},
+		{Timestamp: 1337, Message: "foo"},
+	}, clone.breadcrumbs)
+	assertEqual(t, User{ID: "foo"}, clone.user)
+	assertEqual(t, Request{URL: "foo"}, clone.request)
+
+	assertEqual(t, map[string]string{"foo": "baz"}, scope.tags)
+	assertEqual(t, map[string]interface{}{"foo": "baz"}, scope.contexts)
+	assertEqual(t, map[string]interface{}{"foo": "baz"}, scope.extra)
+	assertEqual(t, LevelFatal, scope.level)
+	assertEqual(t, []string{"bar"}, scope.fingerprint)
+	assertEqual(t, []*Breadcrumb{{Timestamp: 1337, Message: "bar"}}, scope.breadcrumbs)
+	assertEqual(t, User{ID: "bar"}, scope.user)
+	assertEqual(t, Request{URL: "bar"}, scope.request)
+}
+
+func TestClear(t *testing.T) {
+	scope := fillScopeWithData(NewScope())
+	scope.Clear()
+
+	assertEqual(t, []*Breadcrumb{}, scope.breadcrumbs)
+	assertEqual(t, User{}, scope.user)
+	assertEqual(t, map[string]string{}, scope.tags)
+	assertEqual(t, map[string]interface{}{}, scope.contexts)
+	assertEqual(t, map[string]interface{}{}, scope.extra)
+	assertEqual(t, []string{}, scope.fingerprint)
+	assertEqual(t, Level(""), scope.level)
+	assertEqual(t, Request{}, scope.request)
+}
+
+func TestClearAndReconfigure(t *testing.T) {
+	scope := fillScopeWithData(NewScope())
+	scope.Clear()
+
+	scope.SetTag("foo", "bar")
+	scope.SetContext("foo", "bar")
+	scope.SetExtra("foo", "bar")
+	scope.SetLevel(LevelDebug)
+	scope.SetFingerprint([]string{"foo"})
+	scope.AddBreadcrumb(&Breadcrumb{Timestamp: 1337, Message: "foo"}, maxBreadcrumbs)
+	scope.SetUser(User{ID: "foo"})
+	scope.SetRequest(Request{URL: "foo"})
+
+	assertEqual(t, map[string]string{"foo": "bar"}, scope.tags)
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, scope.contexts)
+	assertEqual(t, map[string]interface{}{"foo": "bar"}, scope.extra)
+	assertEqual(t, LevelDebug, scope.level)
+	assertEqual(t, []string{"foo"}, scope.fingerprint)
+	assertEqual(t, []*Breadcrumb{{Timestamp: 1337, Message: "foo"}}, scope.breadcrumbs)
+	assertEqual(t, User{ID: "foo"}, scope.user)
+	assertEqual(t, Request{URL: "foo"}, scope.request)
+}
+
+func TestClearBreadcrumbs(t *testing.T) {
+	scope := fillScopeWithData(NewScope())
+	scope.ClearBreadcrumbs()
+
+	assertEqual(t, []*Breadcrumb{}, scope.breadcrumbs)
+}
+
+func TestApplyToEventWithCorrectScopeAndEvent(t *testing.T) {
+	scope := fillScopeWithData(NewScope())
+	event := fillEventWithData(NewEvent())
+
+	processedEvent := scope.ApplyToEvent(event, nil)
+
+	assertEqual(t, len(processedEvent.Breadcrumbs), 2, "should merge breadcrumbs")
+	assertEqual(t, len(processedEvent.Tags), 2, "should merge tags")
+	assertEqual(t, len(processedEvent.Contexts), 2, "should merge contexts")
+	assertEqual(t, len(processedEvent.Extra), 2, "should merge extra")
+	assertEqual(t, processedEvent.Level, scope.level, "should use scope level if its set")
+	assertNotEqual(t, processedEvent.User, scope.user, "should use event user if one exist")
+	assertNotEqual(t, processedEvent.Request, scope.request, "should use event request if one exist")
+	assertNotEqual(t, processedEvent.Fingerprint, scope.fingerprint, "should use event fingerprints if they exist")
+}
+
+func TestApplyToEventUsingEmptyScope(t *testing.T) {
+	scope := NewScope()
+	event := fillEventWithData(NewEvent())
+
+	processedEvent := scope.ApplyToEvent(event, nil)
+
+	assertEqual(t, len(processedEvent.Breadcrumbs), 1, "should use event breadcrumbs")
+	assertEqual(t, len(processedEvent.Tags), 1, "should use event tags")
+	assertEqual(t, len(processedEvent.Contexts), 1, "should use event contexts")
+	assertEqual(t, len(processedEvent.Extra), 1, "should use event extra")
+	assertNotEqual(t, processedEvent.User, scope.user, "should use event user")
+	assertNotEqual(t, processedEvent.Fingerprint, scope.fingerprint, "should use event fingerprint")
+	assertNotEqual(t, processedEvent.Level, scope.level, "should use event level")
+	assertNotEqual(t, processedEvent.Request, scope.request, "should use event request")
+}
+
+func TestApplyToEventUsingEmptyEvent(t *testing.T) {
+	scope := fillScopeWithData(NewScope())
+	event := NewEvent()
+
+	processedEvent := scope.ApplyToEvent(event, nil)
+
+	assertEqual(t, len(processedEvent.Breadcrumbs), 1, "should use scope breadcrumbs")
+	assertEqual(t, len(processedEvent.Tags), 1, "should use scope tags")
+	assertEqual(t, len(processedEvent.Contexts), 1, "should use scope contexts")
+	assertEqual(t, len(processedEvent.Extra), 1, "should use scope extra")
+	assertEqual(t, processedEvent.User, scope.user, "should use scope user")
+	assertEqual(t, processedEvent.Fingerprint, scope.fingerprint, "should use scope fingerprint")
+	assertEqual(t, processedEvent.Level, scope.level, "should use scope level")
+	assertEqual(t, processedEvent.Request, scope.request, "should use scope request")
+}
+
+func TestEventProcessorsModifiesEvent(t *testing.T) {
+	scope := NewScope()
+	event := NewEvent()
+	scope.eventProcessors = []EventProcessor{
+		func(event *Event, hint *EventHint) *Event {
+			event.Level = LevelFatal
+			return event
+		},
+		func(event *Event, hint *EventHint) *Event {
+			event.Fingerprint = []string{"wat"}
+			return event
+		},
+	}
+	processedEvent := scope.ApplyToEvent(event, nil)
+
+	if processedEvent == nil {
+		t.Error("event should not be dropped")
+	}
+	assertEqual(t, LevelFatal, processedEvent.Level)
+	assertEqual(t, []string{"wat"}, processedEvent.Fingerprint)
+}
+
+func TestEventProcessorsCanDropEvent(t *testing.T) {
+	scope := NewScope()
+	event := NewEvent()
+	scope.eventProcessors = []EventProcessor{
+		func(event *Event, hint *EventHint) *Event {
+			return nil
+		},
+	}
+	processedEvent := scope.ApplyToEvent(event, nil)
+
+	if processedEvent != nil {
+		t.Error("event should be dropped")
+	}
+}
+
+func TestEventProcessorsAddEventProcessor(t *testing.T) {
+	scope := NewScope()
+	event := NewEvent()
+	processedEvent := scope.ApplyToEvent(event, nil)
+
+	if processedEvent == nil {
+		t.Error("event should not be dropped")
+	}
+
+	scope.AddEventProcessor(func(event *Event, hint *EventHint) *Event {
+		return nil
+	})
+	processedEvent = scope.ApplyToEvent(event, nil)
+
+	if processedEvent != nil {
+		t.Error("event should be dropped")
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/scripts/craft-pre-release.sh
+++ b/vendor/github.com/getsentry/sentry-go/scripts/craft-pre-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eux
+
+SCRIPT_DIR="$( dirname "$0" )"
+cd $SCRIPT_DIR/..
+
+function replace() {
+    ! grep "$2" $3
+    perl -i -pe "s/$1/$2/g" $3
+    grep "$2" $3  # verify that replacement was successful
+}
+
+if [ "$#" -eq 1 ]; then
+    OLD_VERSION=""
+    NEW_VERSION="${1}"
+elif [ "$#" -eq 2 ]; then
+    OLD_VERSION="${1}"
+    NEW_VERSION="${2}"
+else
+    echo "Illegal number of parameters"
+    exit 1
+fi
+
+replace "const Version = \"[\w.-]+\"" "const Version = \"$NEW_VERSION\"" ./sentry.go

--- a/vendor/github.com/getsentry/sentry-go/sentry.go
+++ b/vendor/github.com/getsentry/sentry-go/sentry.go
@@ -1,0 +1,122 @@
+package sentry
+
+import (
+	"context"
+	"time"
+)
+
+// Version Sentry-Go SDK Version
+const Version = "0.1.3"
+
+// Init initializes whole SDK by creating new `Client` and binding it to the current `Hub`
+func Init(options ClientOptions) error {
+	hub := CurrentHub()
+	client, err := NewClient(options)
+	if err != nil {
+		return err
+	}
+	hub.BindClient(client)
+	return nil
+}
+
+// AddBreadcrumb records a new breadcrumb.
+//
+// The total number of breadcrumbs that can be recorded are limited by the
+// configuration on the client.
+func AddBreadcrumb(breadcrumb *Breadcrumb) {
+	hub := CurrentHub()
+	hub.AddBreadcrumb(breadcrumb, nil)
+}
+
+// CaptureMessage captures an arbitrary message.
+func CaptureMessage(message string) *EventID {
+	hub := CurrentHub()
+	return hub.CaptureMessage(message)
+}
+
+// CaptureException captures an error.
+func CaptureException(exception error) *EventID {
+	hub := CurrentHub()
+	return hub.CaptureException(exception)
+}
+
+// CaptureEvent captures an event on the currently active client if any.
+//
+// The event must already be assembled. Typically code would instead use
+// the utility methods like `CaptureException`. The return value is the
+// event ID. In case Sentry is disabled or event was dropped, the return value will be nil.
+func CaptureEvent(event *Event) *EventID {
+	hub := CurrentHub()
+	return hub.CaptureEvent(event)
+}
+
+// Recover captures a panic.
+func Recover() *EventID {
+	if err := recover(); err != nil {
+		hub := CurrentHub()
+		return hub.Recover(err)
+	}
+	return nil
+}
+
+// Recover captures a panic and passes relevant context object.
+func RecoverWithContext(ctx context.Context) *EventID {
+	if err := recover(); err != nil {
+		var hub *Hub
+
+		if HasHubOnContext(ctx) {
+			hub = GetHubFromContext(ctx)
+		} else {
+			hub = CurrentHub()
+		}
+
+		return hub.RecoverWithContext(ctx, err)
+	}
+	return nil
+}
+
+// WithScope temporarily pushes a scope for a single call.
+//
+// This function takes one argument, a callback that executes
+// in the context of that scope.
+//
+// This is useful when extra data should be send with a single capture call
+// for instance a different level or tags
+func WithScope(f func(scope *Scope)) {
+	hub := CurrentHub()
+	hub.WithScope(f)
+}
+
+// ConfigureScope invokes a function that can modify the current scope.
+//
+// The function is passed a mutable reference to the `Scope` so that modifications
+// can be performed.
+func ConfigureScope(f func(scope *Scope)) {
+	hub := CurrentHub()
+	hub.ConfigureScope(f)
+}
+
+// PushScope pushes a new scope.
+func PushScope() {
+	hub := CurrentHub()
+	hub.PushScope()
+}
+
+// PopScope pushes a new scope.
+func PopScope() {
+	hub := CurrentHub()
+	hub.PopScope()
+}
+
+// Flush notifies when all the buffered events have been sent by returning `true`
+// or `false` if timeout was reached.
+func Flush(timeout time.Duration) bool {
+	hub := CurrentHub()
+	return hub.Flush(timeout)
+}
+
+// LastEventID returns an ID of last captured event.
+func LastEventID() EventID {
+	hub := CurrentHub()
+	return hub.LastEventID()
+}

--- a/vendor/github.com/getsentry/sentry-go/sourcereader.go
+++ b/vendor/github.com/getsentry/sentry-go/sourcereader.go
@@ -1,0 +1,69 @@
+package sentry
+
+import (
+	"bytes"
+	"io/ioutil"
+	"sync"
+)
+
+type sourceReader struct {
+	mu    sync.Mutex
+	cache map[string][][]byte
+}
+
+func newSourceReader() sourceReader {
+	return sourceReader{
+		cache: make(map[string][][]byte),
+	}
+}
+
+func (sr *sourceReader) readContextLines(filename string, line, context int) ([][]byte, int) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	lines, ok := sr.cache[filename]
+
+	if !ok {
+		data, err := ioutil.ReadFile(filename)
+		if err != nil {
+			sr.cache[filename] = nil
+			return nil, 0
+		}
+		lines = bytes.Split(data, []byte{'\n'})
+		sr.cache[filename] = lines
+	}
+
+	return sr.calculateContextLines(lines, line, context)
+}
+
+// `contextLine` points to a line that caused an issue itself, in relation to returned slice
+func (sr *sourceReader) calculateContextLines(lines [][]byte, line, context int) ([][]byte, int) {
+	// Stacktrace lines are 1-indexed, slices are 0-indexed
+	line--
+
+	contextLine := context
+
+	if lines == nil || line >= len(lines) || line < 0 {
+		return nil, 0
+	}
+
+	if context < 0 {
+		context = 0
+		contextLine = 0
+	}
+
+	start := line - context
+
+	if start < 0 {
+		contextLine += start
+		start = 0
+	}
+
+	end := line + context + 1
+
+	if end > len(lines) {
+		end = len(lines)
+	}
+
+	return lines[start:end], contextLine
+}

--- a/vendor/github.com/getsentry/sentry-go/sourcereader_test.go
+++ b/vendor/github.com/getsentry/sentry-go/sourcereader_test.go
@@ -1,0 +1,129 @@
+package sentry
+
+import (
+	"reflect"
+	"testing"
+)
+
+// nolint: gochecknoglobals
+var input = [][]byte{
+	[]byte("line 1"),
+	[]byte("line 2"),
+	[]byte("line 3"),
+	[]byte("line 4"),
+	[]byte("line 5"),
+}
+
+func assertContextLines(t *testing.T, gotLines, wantLines [][]byte, gotReadLines, wantReadLines int) {
+	t.Helper()
+
+	if !reflect.DeepEqual(gotLines, wantLines) {
+		t.Errorf("incorrect context lines returned. got %s, want %s", gotLines, wantLines)
+	}
+
+	if gotReadLines != wantReadLines {
+		t.Errorf("incorrect context lines count returned. got %d, want %d", gotReadLines, wantReadLines)
+	}
+}
+
+func TestCalculateContextLinesSingleLine(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, 2, 0)
+	wantLines, wantReadLines := [][]byte{
+		[]byte("line 2"),
+	}, 0
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+
+func TestCalculateContextLinesNegativeLine(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, -2, 0)
+	var wantLines [][]byte
+	var wantReadLines int
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+
+func TestCalculateContextLinesNegativeContext(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, 2, -2)
+	wantLines, wantReadLines := [][]byte{
+		[]byte("line 2"),
+	}, 0
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+func TestCalculateContextLinesOverflowLine(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, 10, 0)
+	var wantLines [][]byte
+	var wantReadLines int
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+
+func TestCalculateContextLinesWholeFile(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, 3, 2)
+	wantLines, wantReadLines := [][]byte{
+		[]byte("line 1"),
+		[]byte("line 2"),
+		[]byte("line 3"),
+		[]byte("line 4"),
+		[]byte("line 5"),
+	}, 2
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+
+func TestCalculateContextLinesOverflowContextAtTheTop(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, 2, 3)
+	wantLines, wantReadLines := [][]byte{
+		[]byte("line 1"),
+		[]byte("line 2"),
+		[]byte("line 3"),
+		[]byte("line 4"),
+		[]byte("line 5"),
+	}, 1
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+
+func TestCalculateContextLinesOverflowContextAtTheBottom(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, 5, 3)
+	wantLines, wantReadLines := [][]byte{
+		[]byte("line 2"),
+		[]byte("line 3"),
+		[]byte("line 4"),
+		[]byte("line 5"),
+	}, 3
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+
+func TestCalculateContextLinesOverflowContextBothSides(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.calculateContextLines(input, 2, 10)
+	wantLines, wantReadLines := [][]byte{
+		[]byte("line 1"),
+		[]byte("line 2"),
+		[]byte("line 3"),
+		[]byte("line 4"),
+		[]byte("line 5"),
+	}, 1
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+}
+
+func TestReadContextLinesNonExistingInput(t *testing.T) {
+	sr := newSourceReader()
+	gotLines, gotReadLines := sr.readContextLines("non_existing.go", 2, 10)
+	var wantLines [][]byte
+	var wantReadLines int
+
+	assertContextLines(t, gotLines, wantLines, gotReadLines, wantReadLines)
+	assertEqual(t, sr.cache["non_existing.go"], wantLines)
+}

--- a/vendor/github.com/getsentry/sentry-go/stacktrace.go
+++ b/vendor/github.com/getsentry/sentry-go/stacktrace.go
@@ -1,0 +1,257 @@
+package sentry
+
+import (
+	"go/build"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const unknown string = "unknown"
+
+// The module download is split into two parts: downloading the go.mod and downloading the actual code.
+// If you have dependencies only needed for tests, then they will show up in your go.mod,
+// and go get will download their go.mods, but it will not download their code.
+// The test-only dependencies get downloaded only when you need it, such as the first time you run go test.
+//
+// https://github.com/golang/go/issues/26913#issuecomment-411976222
+
+// Stacktrace holds information about the frames of the stack.
+type Stacktrace struct {
+	Frames        []Frame `json:"frames,omitempty"`
+	FramesOmitted []uint  `json:"frames_omitted,omitempty"`
+}
+
+// NewStacktrace creates a stacktrace using `runtime.Callers`.
+func NewStacktrace() *Stacktrace {
+	pcs := make([]uintptr, 100)
+	n := runtime.Callers(1, pcs)
+
+	if n == 0 {
+		return nil
+	}
+
+	frames := extractFrames(pcs[:n])
+	frames = filterFrames(frames)
+
+	stacktrace := Stacktrace{
+		Frames: frames,
+	}
+
+	return &stacktrace
+}
+
+// ExtractStacktrace creates a new `Stacktrace` based on the given `error` object.
+// TODO: Make it configurable so that anyone can provide their own implementation?
+// Use of reflection allows us to not have a hard dependency on any given package, so we don't have to import it
+func ExtractStacktrace(err error) *Stacktrace {
+	method := extractReflectedStacktraceMethod(err)
+
+	if !method.IsValid() {
+		return nil
+	}
+
+	pcs := extractPcs(method)
+
+	if len(pcs) == 0 {
+		return nil
+	}
+
+	frames := extractFrames(pcs)
+	frames = filterFrames(frames)
+
+	stacktrace := Stacktrace{
+		Frames: frames,
+	}
+
+	return &stacktrace
+}
+
+func extractReflectedStacktraceMethod(err error) reflect.Value {
+	var method reflect.Value
+
+	// https://github.com/pingcap/errors
+	methodGetStackTracer := reflect.ValueOf(err).MethodByName("GetStackTracer")
+	// https://github.com/pkg/errors
+	methodStackTrace := reflect.ValueOf(err).MethodByName("StackTrace")
+	// https://github.com/go-errors/errors
+	methodStackFrames := reflect.ValueOf(err).MethodByName("StackFrames")
+
+	if methodGetStackTracer.IsValid() {
+		stacktracer := methodGetStackTracer.Call(make([]reflect.Value, 0))[0]
+		stacktracerStackTrace := reflect.ValueOf(stacktracer).MethodByName("StackTrace")
+
+		if stacktracerStackTrace.IsValid() {
+			method = stacktracerStackTrace
+		}
+	}
+
+	if methodStackTrace.IsValid() {
+		method = methodStackTrace
+	}
+
+	if methodStackFrames.IsValid() {
+		method = methodStackFrames
+	}
+
+	return method
+}
+
+func extractPcs(method reflect.Value) []uintptr {
+	var pcs []uintptr
+
+	stacktrace := method.Call(make([]reflect.Value, 0))[0]
+
+	if stacktrace.Kind() != reflect.Slice {
+		return nil
+	}
+
+	for i := 0; i < stacktrace.Len(); i++ {
+		pc := stacktrace.Index(i)
+
+		if pc.Kind() == reflect.Uintptr {
+			pcs = append(pcs, uintptr(pc.Uint()))
+			continue
+		}
+
+		if pc.Kind() == reflect.Struct {
+			field := pc.FieldByName("ProgramCounter")
+			if field.IsValid() && field.Kind() == reflect.Uintptr {
+				pcs = append(pcs, uintptr(field.Uint()))
+				continue
+			}
+		}
+	}
+
+	return pcs
+}
+
+// https://docs.sentry.io/development/sdk-dev/interfaces/stacktrace/
+type Frame struct {
+	Function    string                 `json:"function,omitempty"`
+	Symbol      string                 `json:"symbol,omitempty"`
+	Module      string                 `json:"module,omitempty"`
+	Package     string                 `json:"package,omitempty"`
+	Filename    string                 `json:"filename,omitempty"`
+	AbsPath     string                 `json:"abs_path,omitempty"`
+	Lineno      int                    `json:"lineno,omitempty"`
+	Colno       int                    `json:"colno,omitempty"`
+	PreContext  []string               `json:"pre_context,omitempty"`
+	ContextLine string                 `json:"context_line,omitempty"`
+	PostContext []string               `json:"post_context,omitempty"`
+	InApp       bool                   `json:"in_app,omitempty"`
+	Vars        map[string]interface{} `json:"vars,omitempty"`
+}
+
+// NewFrame assembles a stacktrace frame out of `runtime.Frame`.
+func NewFrame(f runtime.Frame) Frame {
+	abspath := f.File
+	filename := f.File
+	function := f.Function
+	var module string
+
+	if filename != "" {
+		filename = extractFilename(filename)
+	} else {
+		filename = unknown
+	}
+
+	if abspath == "" {
+		abspath = unknown
+	}
+
+	if function != "" {
+		module, function = deconstructFunctionName(function)
+	}
+
+	frame := Frame{
+		AbsPath:  abspath,
+		Filename: filename,
+		Lineno:   f.Line,
+		Module:   module,
+		Function: function,
+	}
+
+	frame.InApp = isInAppFrame(frame)
+
+	return frame
+}
+
+func extractFrames(pcs []uintptr) []Frame {
+	var frames []Frame
+	callersFrames := runtime.CallersFrames(pcs)
+
+	for {
+		callerFrame, more := callersFrames.Next()
+
+		frames = append([]Frame{
+			NewFrame(callerFrame),
+		}, frames...)
+
+		if !more {
+			break
+		}
+	}
+
+	return frames
+}
+
+func filterFrames(frames []Frame) []Frame {
+	isTestFileRegexp := regexp.MustCompile(`getsentry/sentry-go/.+_test.go`)
+	isExampleFileRegexp := regexp.MustCompile(`getsentry/sentry-go/example/`)
+	filteredFrames := make([]Frame, 0, len(frames))
+
+	for _, frame := range frames {
+		// go runtime frames
+		if frame.Module == "runtime" || frame.Module == "testing" {
+			continue
+		}
+		// sentry internal frames
+		isTestFile := isTestFileRegexp.MatchString(frame.AbsPath)
+		isExampleFile := isExampleFileRegexp.MatchString(frame.AbsPath)
+		if strings.Contains(frame.AbsPath, "github.com/getsentry/sentry-go") &&
+			!isTestFile &&
+			!isExampleFile {
+			continue
+		}
+		filteredFrames = append(filteredFrames, frame)
+	}
+
+	return filteredFrames
+}
+
+func extractFilename(path string) string {
+	_, file := filepath.Split(path)
+	return file
+}
+
+func isInAppFrame(frame Frame) bool {
+	if strings.HasPrefix(frame.AbsPath, build.Default.GOROOT) ||
+		strings.Contains(frame.Module, "vendor") ||
+		strings.Contains(frame.Module, "third_party") {
+		return false
+	}
+
+	return true
+}
+
+// Transform `runtime/debug.*T·ptrmethod` into `{ module: runtime/debug, function: *T.ptrmethod }`
+func deconstructFunctionName(name string) (module string, function string) {
+	if idx := strings.LastIndex(name, "."); idx != -1 {
+		module = name[:idx]
+		function = name[idx+1:]
+	}
+	function = strings.Replace(function, "·", ".", -1)
+	return module, function
+}
+
+func callerFunctionName() string {
+	pcs := make([]uintptr, 1)
+	runtime.Callers(3, pcs)
+	callersFrames := runtime.CallersFrames(pcs)
+	callerFrame, _ := callersFrames.Next()
+	_, function := deconstructFunctionName(callerFrame.Function)
+	return function
+}

--- a/vendor/github.com/getsentry/sentry-go/stacktrace_test.go
+++ b/vendor/github.com/getsentry/sentry-go/stacktrace_test.go
@@ -1,0 +1,84 @@
+package sentry
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestFunctionName(t *testing.T) {
+	for _, test := range []struct {
+		skip int
+		pack string
+		name string
+	}{
+		{0, "sentry-go", "TestFunctionName"},
+		{1, "testing", "tRunner"},
+		{2, "runtime", "goexit"},
+		{100, "", ""},
+	} {
+		pc, _, _, _ := runtime.Caller(test.skip)
+		pack, name := deconstructFunctionName(runtime.FuncForPC(pc).Name())
+
+		// Go1.10 reports different paths than Modules aware versions (>=1.11)
+		assertStringContains(t, pack, test.pack)
+		assertEqual(t, name, test.name)
+	}
+}
+
+func TestNewStacktrace(t *testing.T) {
+	stacktrace := Trace()
+
+	assertEqual(t, len(stacktrace.Frames), 2)
+	assertEqual(t, stacktrace.Frames[0].Function, "TestNewStacktrace")
+	assertEqual(t, stacktrace.Frames[1].Function, "Trace")
+}
+
+func TestStacktraceFrame(t *testing.T) {
+	_, callerFile, _, _ := runtime.Caller(0)
+	dir, _ := filepath.Split(callerFile)
+
+	stacktrace := Trace()
+	frame := stacktrace.Frames[len(stacktrace.Frames)-1]
+
+	assertEqual(t, frame.Filename, "errors_test.go")
+	assertEqual(t, frame.AbsPath, filepath.Join(dir, "errors_test.go"))
+	assertEqual(t, frame.Function, "Trace")
+	assertEqual(t, frame.Lineno, 12)
+	assertEqual(t, frame.InApp, true)
+	// Go1.10 reports different Module than Modules aware versions (>=1.11)
+	assertStringContains(t, frame.Module, "sentry-go")
+}
+
+// https://github.com/pkg/errors
+func TestExtractStacktracePkgErrors(t *testing.T) {
+	err := RedPkgErrorsRanger()
+	stacktrace := ExtractStacktrace(err)
+
+	assertEqual(t, len(stacktrace.Frames), 3)
+	assertEqual(t, stacktrace.Frames[0].Function, "TestExtractStacktracePkgErrors")
+	assertEqual(t, stacktrace.Frames[1].Function, "RedPkgErrorsRanger")
+	assertEqual(t, stacktrace.Frames[2].Function, "BluePkgErrorsRanger")
+}
+
+// https://github.com/pingcap/errors
+func TestExtractStacktracePingcapErrors(t *testing.T) {
+	err := RedPingcapErrorsRanger()
+	stacktrace := ExtractStacktrace(err)
+
+	assertEqual(t, len(stacktrace.Frames), 3)
+	assertEqual(t, stacktrace.Frames[0].Function, "TestExtractStacktracePingcapErrors")
+	assertEqual(t, stacktrace.Frames[1].Function, "RedPingcapErrorsRanger")
+	assertEqual(t, stacktrace.Frames[2].Function, "BluePingcapErrorsRanger")
+}
+
+// https://github.com/go-errors/errors
+func TestExtractStacktraceGoErrors(t *testing.T) {
+	err := RedGoErrorsRanger()
+	stacktrace := ExtractStacktrace(err)
+
+	assertEqual(t, len(stacktrace.Frames), 3)
+	assertEqual(t, stacktrace.Frames[0].Function, "TestExtractStacktraceGoErrors")
+	assertEqual(t, stacktrace.Frames[1].Function, "RedGoErrorsRanger")
+	assertEqual(t, stacktrace.Frames[2].Function, "BlueGoErrorsRanger")
+}

--- a/vendor/github.com/getsentry/sentry-go/transport.go
+++ b/vendor/github.com/getsentry/sentry-go/transport.go
@@ -1,0 +1,316 @@
+package sentry
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const defaultBufferSize = 30
+const defaultRetryAfter = time.Second * 60
+const defaultTimeout = time.Second * 30
+
+// Transport is used by the `Client` to deliver events to remote server.
+type Transport interface {
+	Flush(timeout time.Duration) bool
+	Configure(options ClientOptions)
+	SendEvent(event *Event)
+}
+
+func getProxyConfig(options ClientOptions) func(*http.Request) (*url.URL, error) {
+	if options.HTTPSProxy != "" {
+		return func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(options.HTTPSProxy)
+		}
+	} else if options.HTTPProxy != "" {
+		return func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(options.HTTPProxy)
+		}
+	}
+
+	return http.ProxyFromEnvironment
+}
+
+func getTLSConfig(options ClientOptions) *tls.Config {
+	if options.CaCerts != nil {
+		return &tls.Config{
+			RootCAs: options.CaCerts,
+		}
+	}
+
+	return nil
+}
+
+func retryAfter(now time.Time, r *http.Response) time.Duration {
+	retryAfterHeader := r.Header["Retry-After"]
+
+	if retryAfterHeader == nil {
+		return defaultRetryAfter
+	}
+
+	if date, err := time.Parse(time.RFC1123, retryAfterHeader[0]); err == nil {
+		return date.Sub(now)
+	}
+
+	if seconds, err := strconv.Atoi(retryAfterHeader[0]); err == nil {
+		return time.Second * time.Duration(seconds)
+	}
+
+	return defaultRetryAfter
+}
+
+// ================================
+// HTTPTransport
+// ================================
+
+// HTTPTransport is a default implementation of `Transport` interface used by `Client`.
+type HTTPTransport struct {
+	dsn       *Dsn
+	client    *http.Client
+	transport *http.Transport
+
+	buffer        chan *http.Request
+	disabledUntil time.Time
+
+	wg    sync.WaitGroup
+	start sync.Once
+
+	// Size of the transport buffer. Defaults to 30.
+	BufferSize int
+	// HTTP Client request timeout. Defaults to 30 seconds.
+	Timeout time.Duration
+}
+
+// NewHTTPTransport returns a new pre-configured instance of HTTPTransport
+func NewHTTPTransport() *HTTPTransport {
+	transport := HTTPTransport{
+		BufferSize: defaultBufferSize,
+		Timeout:    defaultTimeout,
+	}
+	return &transport
+}
+
+// Configure is called by the `Client` itself, providing it it's own `ClientOptions`.
+func (t *HTTPTransport) Configure(options ClientOptions) {
+	dsn, err := NewDsn(options.Dsn)
+	if err != nil {
+		Logger.Printf("%v\n", err)
+		return
+	}
+
+	t.dsn = dsn
+	t.buffer = make(chan *http.Request, t.BufferSize)
+
+	if options.HTTPTransport != nil {
+		t.transport = options.HTTPTransport
+	} else {
+		t.transport = &http.Transport{
+			Proxy:           getProxyConfig(options),
+			TLSClientConfig: getTLSConfig(options),
+		}
+	}
+
+	t.client = &http.Client{
+		Transport: t.transport,
+		Timeout:   t.Timeout,
+	}
+
+	t.start.Do(func() {
+		go t.worker()
+	})
+}
+
+// SendEvent assembles a new packet out of `Event` and sends it to remote server.
+func (t *HTTPTransport) SendEvent(event *Event) {
+	if t.dsn == nil || time.Now().Before(t.disabledUntil) {
+		return
+	}
+
+	body, _ := json.Marshal(event)
+
+	request, _ := http.NewRequest(
+		http.MethodPost,
+		t.dsn.StoreAPIURL().String(),
+		bytes.NewBuffer(body),
+	)
+
+	for headerKey, headerValue := range t.dsn.RequestHeaders() {
+		request.Header.Set(headerKey, headerValue)
+	}
+
+	t.wg.Add(1)
+
+	select {
+	case t.buffer <- request:
+		Logger.Printf(
+			"Sending %s event [%s] to %s project: %d\n",
+			event.Level,
+			event.EventID,
+			t.dsn.host,
+			t.dsn.projectID,
+		)
+	default:
+		t.wg.Done()
+		Logger.Println("Event dropped due to transport buffer being full.")
+		// worker would block, drop the packet
+	}
+}
+
+// Flush notifies when all the buffered events have been sent by returning `true`
+// or `false` if timeout was reached.
+func (t *HTTPTransport) Flush(timeout time.Duration) bool {
+	c := make(chan struct{})
+
+	go func() {
+		t.wg.Wait()
+		close(c)
+	}()
+
+	select {
+	case <-c:
+		Logger.Println("Buffer flushed successfully.")
+		return true
+	case <-time.After(timeout):
+		Logger.Println("Buffer flushing reached the timeout.")
+		return false
+	}
+}
+
+func (t *HTTPTransport) worker() {
+	for request := range t.buffer {
+		if time.Now().Before(t.disabledUntil) {
+			t.wg.Done()
+			continue
+		}
+
+		response, err := t.client.Do(request)
+
+		if err != nil {
+			Logger.Printf("There was an issue with sending an event: %v", err)
+		}
+
+		if response != nil && response.StatusCode == http.StatusTooManyRequests {
+			t.disabledUntil = time.Now().Add(retryAfter(time.Now(), response))
+			Logger.Printf("Too many requests, backing off till: %s\n", t.disabledUntil)
+		}
+
+		t.wg.Done()
+	}
+}
+
+// ================================
+// HTTPSyncTransport
+// ================================
+
+// HTTPSyncTransport is an implementation of `Transport` interface which blocks after each captured event.
+type HTTPSyncTransport struct {
+	dsn           *Dsn
+	client        *http.Client
+	transport     *http.Transport
+	disabledUntil time.Time
+
+	// HTTP Client request timeout. Defaults to 30 seconds.
+	Timeout time.Duration
+}
+
+// NewHTTPSyncTransport returns a new pre-configured instance of HTTPSyncTransport
+func NewHTTPSyncTransport() *HTTPSyncTransport {
+	transport := HTTPSyncTransport{
+		Timeout: defaultTimeout,
+	}
+
+	return &transport
+}
+
+// Configure is called by the `Client` itself, providing it it's own `ClientOptions`.
+func (t *HTTPSyncTransport) Configure(options ClientOptions) {
+	dsn, err := NewDsn(options.Dsn)
+	if err != nil {
+		Logger.Printf("%v\n", err)
+		return
+	}
+	t.dsn = dsn
+
+	if options.HTTPTransport != nil {
+		t.transport = options.HTTPTransport
+	} else {
+		t.transport = &http.Transport{
+			Proxy:           getProxyConfig(options),
+			TLSClientConfig: getTLSConfig(options),
+		}
+	}
+
+	t.client = &http.Client{
+		Transport: t.transport,
+		Timeout:   t.Timeout,
+	}
+}
+
+// SendEvent assembles a new packet out of `Event` and sends it to remote server.
+func (t *HTTPSyncTransport) SendEvent(event *Event) {
+	if t.dsn == nil || time.Now().Before(t.disabledUntil) {
+		return
+	}
+
+	body, _ := json.Marshal(event)
+
+	request, _ := http.NewRequest(
+		http.MethodPost,
+		t.dsn.StoreAPIURL().String(),
+		bytes.NewBuffer(body),
+	)
+
+	for headerKey, headerValue := range t.dsn.RequestHeaders() {
+		request.Header.Set(headerKey, headerValue)
+	}
+
+	Logger.Printf(
+		"Sending %s event [%s] to %s project: %d\n",
+		event.Level,
+		event.EventID,
+		t.dsn.host,
+		t.dsn.projectID,
+	)
+
+	response, err := t.client.Do(request)
+
+	if err != nil {
+		Logger.Printf("There was an issue with sending an event: %v", err)
+	}
+
+	if response != nil && response.StatusCode == http.StatusTooManyRequests {
+		t.disabledUntil = time.Now().Add(retryAfter(time.Now(), response))
+		Logger.Printf("Too many requests, backing off till: %s\n", t.disabledUntil)
+	}
+}
+
+// Flush notifies when all the buffered events have been sent by returning `true`
+// or `false` if timeout was reached. No-op for HTTPSyncTransport.
+func (t *HTTPSyncTransport) Flush(_ time.Duration) bool {
+	return true
+}
+
+// ================================
+// noopTransport
+// ================================
+
+// noopTransport is an implementation of `Transport` interface which drops all the events.
+// Only used internally when an empty DSN is provided, which effectively disables the SDK.
+type noopTransport struct{}
+
+func (t *noopTransport) Configure(options ClientOptions) {
+	Logger.Println("Sentry client initialized with an empty DSN. Using noopTransport. No events will be delivered.")
+}
+
+func (t *noopTransport) SendEvent(event *Event) {
+	Logger.Println("Event dropped due to noopTransport usage.")
+}
+
+func (t *noopTransport) Flush(_ time.Duration) bool {
+	return true
+}

--- a/vendor/github.com/getsentry/sentry-go/transport_test.go
+++ b/vendor/github.com/getsentry/sentry-go/transport_test.go
@@ -1,0 +1,40 @@
+package sentry
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRetryAfterNoHeader(t *testing.T) {
+	r := http.Response{}
+	assertEqual(t, retryAfter(time.Now(), &r), time.Second*60)
+}
+
+func TestRetryAfterIncorrectHeader(t *testing.T) {
+	r := http.Response{
+		Header: map[string][]string{
+			"Retry-After": {"x"},
+		},
+	}
+	assertEqual(t, retryAfter(time.Now(), &r), time.Second*60)
+}
+
+func TestRetryAfterDelayHeader(t *testing.T) {
+	r := http.Response{
+		Header: map[string][]string{
+			"Retry-After": {"1337"},
+		},
+	}
+	assertEqual(t, retryAfter(time.Now(), &r), time.Second*1337)
+}
+
+func TestRetryAfterDateHeader(t *testing.T) {
+	now, _ := time.Parse(time.RFC1123, "Wed, 21 Oct 2015 07:28:00 GMT")
+	r := http.Response{
+		Header: map[string][]string{
+			"Retry-After": {"Wed, 21 Oct 2015 07:28:13 GMT"},
+		},
+	}
+	assertEqual(t, retryAfter(now, &r), time.Second*13)
+}

--- a/vendor/github.com/getsentry/sentry-go/util.go
+++ b/vendor/github.com/getsentry/sentry-go/util.go
@@ -1,0 +1,34 @@
+package sentry
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+func uuid() string {
+	id := make([]byte, 16)
+	_, _ = io.ReadFull(rand.Reader, id)
+	id[6] &= 0x0F // clear version
+	id[6] |= 0x40 // set version to 4 (random uuid)
+	id[8] &= 0x3F // clear variant
+	id[8] |= 0x80 // set to IETF variant
+	return hex.EncodeToString(id)
+}
+
+func fileExists(fileName string) bool {
+	if _, err := os.Stat(fileName); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// nolint: deadcode, unused
+func prettyPrint(data interface{}) {
+	dbg, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Println(string(dbg))
+}

--- a/vendor/github.com/getsentry/sentry-go/util_test.go
+++ b/vendor/github.com/getsentry/sentry-go/util_test.go
@@ -1,0 +1,29 @@
+package sentry
+
+import (
+	"testing"
+)
+
+func TestUUIDReturnsRandom32CharacterString(t *testing.T) {
+	u1 := uuid()
+	u2 := uuid()
+	u3 := uuid()
+
+	assertEqual(t, len(u1), 32)
+	assertEqual(t, len(u2), 32)
+	assertEqual(t, len(u3), 32)
+
+	assertNotEqual(t, u1, u2)
+	assertNotEqual(t, u1, u3)
+	assertNotEqual(t, u2, u3)
+}
+
+func TestFileExistsReturnsTrueForExistingFiles(t *testing.T) {
+	assertEqual(t, fileExists(("util.go")), true)
+	assertEqual(t, fileExists(("util_test.go")), true)
+}
+
+func TestFileExistsReturnsFalseForNonExistingFiles(t *testing.T) {
+	assertEqual(t, fileExists(("util_nope.go")), false)
+	assertEqual(t, fileExists(("util_nope_test.go")), false)
+}


### PR DESCRIPTION
Trello: https://trello.com/c/detFSKHk/335-send-router-errors-to-sentry

This will send errors that we currently store in the logs to Sentry.

I put it on integration and staging and it picked up some licensify errors and some others. If you look at app-router in Sentry you can check the result of this.

We won't report timeout errors as this will take up too much of our Sentry quota.