### PR TITLE
Close request body on error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,5 @@ require (
 	golang.org/x/net v0.0.0-20160717224510-3797cd886499 // indirect
 	golang.org/x/sys v0.0.0-20160717071931-a646d33e2ee3 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/mgo.v2 v2.0.0-20160609180028-29cc868a5ca6 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20160715033755-e4d366fc3c79 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/getsentry/sentry-go v0.2.1 h1:zCyr8wS1NQM7ixbWNh8lBRMlQZSM3aMXQCqXgCD
 github.com/getsentry/sentry-go v0.2.1/go.mod h1:2QfSdvxz4IZGyB5izm1TtADFhlhfj1Dcesrg8+A/T9Y=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/golang/protobuf v0.0.0-20160712193813-874264fbbb43 h1:hqD5LoecFbk/F8KRMF5THTQDx6HLNdfCcth8BDpy6JQ=
 github.com/golang/protobuf v0.0.0-20160712193813-874264fbbb43/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -16,7 +17,9 @@ github.com/onsi/ginkgo v0.0.0-20160716051733-7d3240191d7b h1:tQgOdRdXLi5UmMEBGnz
 github.com/onsi/ginkgo v0.0.0-20160716051733-7d3240191d7b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20160713044445-9574b2d94c03 h1:0KuWmiYjZpQkXeyUgpH7dbSCPdNxZQOpsUuMNaYC0E8=
 github.com/onsi/gomega v0.0.0-20160713044445-9574b2d94c03/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/pingcap/errors v0.11.1 h1:BXFZ6MdDd2U1uJUa2sRAWTmm+nieEzuyYM0R4aUTcC8=
 github.com/pingcap/errors v0.11.1/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 h1:7z3LSn867ex6VSaahyKadf4WtSsJIgne6A1WLOAGM8A=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
@@ -28,6 +31,5 @@ golang.org/x/sys v0.0.0-20160717071931-a646d33e2ee3 h1:ZLExsLvnoqWSw6JB6k6RjWobI
 golang.org/x/sys v0.0.0-20160717071931-a646d33e2ee3/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/mgo.v2 v2.0.0-20160609180028-29cc868a5ca6/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/yaml.v2 v2.0.0-20160715033755-e4d366fc3c79 h1:mENkfeXGmLV7lIyBeNdwYWdONek7pH9yHaHMgZyvIWE=
 gopkg.in/yaml.v2 v2.0.0-20160715033755-e4d366fc3c79/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/handlers/backend_handler.go
+++ b/handlers/backend_handler.go
@@ -74,6 +74,12 @@ func newBackendTransport(connectTimeout, headerTimeout time.Duration, logger log
 	return
 }
 
+func closeBody(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+}
+
 func (bt *backendTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	resp, err = bt.wrapped.RoundTrip(req)
 	if err == nil {
@@ -83,6 +89,7 @@ func (bt *backendTransport) RoundTrip(req *http.Request) (resp *http.Response, e
 		logDetails := map[string]interface{}{"error": err.Error(), "status": 500}
 		defer bt.logger.LogFromBackendRequest(logDetails, req)
 		defer logger.NotifySentry(logger.ReportableError{ Error: err, Request: req, Response: resp })
+		defer closeBody(resp)
 
 		// Intercept some specific errors and generate an appropriate HTTP error response
 		if netErr, ok := err.(net.Error); ok {

--- a/handlers/backend_handler_test.go
+++ b/handlers/backend_handler_test.go
@@ -1,0 +1,135 @@
+package handlers_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/alphagov/router/handlers"
+	log "github.com/alphagov/router/logger"
+)
+
+var _ = Describe("Backend handler", func() {
+	var (
+		timeout = 1 * time.Second
+		logger  log.Logger
+
+		backend    *ghttp.Server
+		backendURL *url.URL
+
+		rw     *httptest.ResponseRecorder
+		router http.Handler
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		logger, err = log.New(GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Could not create logger")
+
+		backend = ghttp.NewServer()
+
+		backendURL, err = url.Parse(backend.URL())
+		Expect(err).NotTo(HaveOccurred(), "Could not parse backend URL")
+
+		rw = httptest.NewRecorder()
+	})
+
+	AfterEach(func() {
+		backend.Close()
+	})
+
+	Context("when the backend times out", func() {
+		BeforeEach(func() {
+			router = handlers.NewBackendHandler(
+				backendURL,
+				timeout, timeout,
+				logger,
+			)
+
+			backend.AppendHandlers(func(rw http.ResponseWriter, r *http.Request) {
+				time.Sleep(timeout * 2)
+				rw.WriteHeader(http.StatusOK)
+			})
+
+			router.ServeHTTP(
+				rw,
+				httptest.NewRequest("GET", backendURL.String(), nil),
+			)
+		})
+
+		It("should return HTTP 504", func() {
+			Expect(rw.Result().StatusCode).To(Equal(http.StatusGatewayTimeout))
+		})
+
+		It("should not populate the Via header", func() {
+			Expect(rw.Result().Header.Get("Via")).To(Equal(""))
+		})
+	})
+
+	Context("when the backend handles the connection", func() {
+		BeforeEach(func() {
+			router = handlers.NewBackendHandler(
+				backendURL,
+				timeout, timeout,
+				logger,
+			)
+		})
+
+		Context("when the proxied request returns 200", func() {
+			BeforeEach(func() {
+				backend.AppendHandlers(ghttp.RespondWith(200, "Hello World"))
+
+				router.ServeHTTP(
+					rw,
+					httptest.NewRequest("GET", backendURL.String(), nil),
+				)
+			})
+
+			It("should return 200", func() {
+				Expect(rw.Result().StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("should return the body", func() {
+				body, err := ioutil.ReadAll(rw.Result().Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(body)).To(Equal("Hello World"))
+			})
+
+			It("should populate the Via header", func() {
+				Expect(rw.Result().Header.Get("Via")).To(Equal("1.1 router"))
+			})
+		})
+
+		Context("when the proxied request returns 403", func() {
+			BeforeEach(func() {
+				backend.AppendHandlers(ghttp.RespondWith(403, "Forbidden"))
+
+				router.ServeHTTP(
+					rw,
+					httptest.NewRequest("GET", backendURL.String(), nil),
+				)
+			})
+
+			It("should return 403", func() {
+				Expect(rw.Result().StatusCode).To(Equal(http.StatusForbidden))
+			})
+
+			It("should return the body", func() {
+				body, err := ioutil.ReadAll(rw.Result().Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(body)).To(Equal("Forbidden"))
+			})
+
+			It("should populate the Via header", func() {
+				Expect(rw.Result().Header.Get("Via")).To(Equal("1.1 router"))
+			})
+		})
+	})
+})

--- a/handlers/handlers_suite_test.go
+++ b/handlers/handlers_suite_test.go
@@ -1,0 +1,13 @@
+package handlers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handlers Suite")
+}

--- a/handlers/redirect_handler_test.go
+++ b/handlers/redirect_handler_test.go
@@ -1,0 +1,160 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/alphagov/router/handlers"
+)
+
+type redirectTableEntry struct {
+	preserve  bool
+	temporary bool
+}
+
+var _ = Describe("Redirect handlers", func() {
+	entries := []TableEntry{
+		Entry(
+			"when redirects are temporary and paths are preserved",
+			redirectTableEntry{preserve: true, temporary: true},
+		),
+		Entry(
+			"when redirects are temporary and paths are not preserved",
+			redirectTableEntry{preserve: false, temporary: true},
+		),
+		Entry(
+			"when redirects are not temporary and paths are preserved",
+			redirectTableEntry{preserve: true, temporary: false},
+		),
+		Entry(
+			"when redirects are not temporary and paths are not preserved",
+			redirectTableEntry{preserve: false, temporary: false},
+		),
+	}
+
+	DescribeTable(
+		"handlers",
+		func(t redirectTableEntry) {
+			rw := httptest.NewRecorder()
+
+			handler := handlers.NewRedirectHandler(
+				"/source-prefix", "/target-prefix",
+				t.preserve, t.temporary,
+			)
+
+			handler.ServeHTTP(
+				rw,
+				httptest.NewRequest(
+					"GET",
+					"https://source.gov.uk/source-prefix/path/subpath?query1=a&query2=b",
+					nil,
+				),
+			)
+
+			if t.temporary {
+				// HTTP 302 is returned instead of 307
+				// because we want the route to be cached temporarily
+				// and not rerequested immediately
+				Expect(rw.Result().StatusCode).To(
+					Equal(http.StatusFound),
+					"when the redirect is temporary we should return HTTP 302",
+				)
+			} else {
+				Expect(rw.Result().StatusCode).To(
+					Equal(http.StatusMovedPermanently),
+					"when the redirect is permanent we should return HTTP 301",
+				)
+			}
+
+			if t.preserve {
+				Expect(rw.Result().Header.Get("Location")).To(
+					Equal("/target-prefix/path/subpath?query1=a&query2=b"),
+				)
+			} else {
+				Expect(rw.Result().Header.Get("Location")).To(
+					Equal("/target-prefix"),
+					"when we do not preserve the path, we redirect straight to target",
+				)
+			}
+
+			Expect(rw.Result().Header.Get("Cache-Control")).To(
+				SatisfyAll(
+					ContainSubstring("public"),
+					ContainSubstring("max-age=1800"),
+				),
+				"Declare public and cachable for 30 minutes",
+			)
+
+			Expect(rw.Result().Header.Get("Expires")).To(
+				WithTransform(
+					func(timestr string) time.Time {
+						t, err := time.Parse(time.RFC1123, timestr)
+						Expect(err).NotTo(HaveOccurred(), "Not RFC1123 compliant")
+						return t
+					},
+					BeTemporally("~", time.Now().Add(30*time.Minute), 1*time.Second),
+				),
+				"Be RFC1123 compliant and expire around 30 minutes in the future",
+			)
+		},
+		entries...,
+	)
+
+	Context("when we are not preserving paths", func() {
+		var (
+			rw      *httptest.ResponseRecorder
+			handler http.Handler
+		)
+
+		BeforeEach(func() {
+			rw = httptest.NewRecorder()
+
+			handler = handlers.NewRedirectHandler(
+				"/source-prefix", "/target-prefix",
+				false, // preserve
+				true,  // temporary
+			)
+		})
+
+		Context("when the _ga query param is present", func() {
+			It("should persist _ga to the query params", func() {
+				handler.ServeHTTP(
+					rw,
+					httptest.NewRequest(
+						"GET",
+						"https://source.gov.uk/source-prefix?_ga=dontbeevil",
+						nil,
+					),
+				)
+
+				Expect(rw.Result().Header.Get("Location")).To(
+					Equal("/target-prefix?_ga=dontbeevil"),
+					"Preserve the _ga query parameter",
+				)
+			})
+		})
+
+		Context("when the _ga query param is not present", func() {
+			It("should not add _ga to the query params", func() {
+				handler.ServeHTTP(
+					rw,
+					httptest.NewRequest(
+						"GET",
+						"https://source.gov.uk/source-prefix?param=begood",
+						nil,
+					),
+				)
+
+				Expect(rw.Result().Header.Get("Location")).To(
+					Equal("/target-prefix"),
+					"Do not have any query params",
+				)
+			})
+		})
+	})
+})


### PR DESCRIPTION
Tests a change to router whereby if an error is thrown for a request, 
the response body is closed.

This comes off the back of a hypothesis from @tlwr on what could be
causing the increased amount of open files on the cache machines.

The increased file handles only seem to occur in production, but we have 
deployed the branch changes to staging to see if any unusual behaviour occurs
before 'testing' this in prod.

Co-authored: @bilbof 

Related incident:
https://docs.google.com/document/d/1gCCSj-WgtK0_TY19J00qf4PiNV5z0KFoLArWkPBgGAg/edit#