### PR TITLE
[spike] Return a 405 if routes does not allow a method

### DIFF
--- a/integration_tests/gone_test.go
+++ b/integration_tests/gone_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Gone routes", func() {
 
 		resp = routerRequest("/foo/bar")
 		Expect(resp.StatusCode).To(Equal(404))
-		Expect(readBody(resp)).To(Equal("404 page not found\n"))
+		Expect(readBody(resp)).To(Equal("404 Not Found\n"))
 	})
 
 	It("should support a prefix gone route", func() {

--- a/integration_tests/http_request_helpers.go
+++ b/integration_tests/http_request_helpers.go
@@ -13,7 +13,11 @@ import (
 )
 
 func routerRequest(path string, optionalPort ...int) *http.Response {
-	return doRequest(newRequest("GET", routerURL(path, optionalPort...)))
+	return routerRequestWithMethod("GET", path, optionalPort...)
+}
+
+func routerRequestWithMethod(method string, path string, optionalPort ...int) *http.Response {
+	return doRequest(newRequest(method, routerURL(path, optionalPort...)))
 }
 
 func routerRequestWithHeaders(path string, headers map[string]string, optionalPort ...int) *http.Response {

--- a/integration_tests/route_helpers.go
+++ b/integration_tests/route_helpers.go
@@ -21,20 +21,22 @@ var (
 )
 
 type Route struct {
-	IncomingPath string `bson:"incoming_path"`
-	RouteType    string `bson:"route_type"`
-	Handler      string `bson:"handler"`
-	BackendID    string `bson:"backend_id"`
-	RedirectTo   string `bson:"redirect_to"`
-	RedirectType string `bson:"redirect_type"`
-	SegmentsMode string `bson:"segments_mode"`
-	Disabled     bool   `bson:"disabled"`
+	IncomingPath string    `bson:"incoming_path"`
+	RouteType    string    `bson:"route_type"`
+	Handler      string    `bson:"handler"`
+	BackendID    string    `bson:"backend_id"`
+	Methods      []string  `bson:"methods"`
+	RedirectTo   string    `bson:"redirect_to"`
+	RedirectType string    `bson:"redirect_type"`
+	SegmentsMode string    `bson:"segments_mode"`
+	Disabled     bool      `bson:"disabled"`
 }
 
-func NewBackendRoute(backendID string, extraParams ...string) Route {
+func NewBackendRouteWithMethods(backendID string, methods []string, extraParams ...string) Route {
 	route := Route{
 		Handler:   "backend",
 		BackendID: backendID,
+		Methods:   methods,
 	}
 
 	if len(extraParams) > 0 {
@@ -42,6 +44,10 @@ func NewBackendRoute(backendID string, extraParams ...string) Route {
 	}
 
 	return route
+}
+
+func NewBackendRoute(backendID string, extraParams ...string) Route {
+	return NewBackendRouteWithMethods(backendID, []string{}, extraParams...)
 }
 
 func NewRedirectRoute(redirectTo string, extraParams ...string) Route {

--- a/triemux/mux.go
+++ b/triemux/mux.go
@@ -9,6 +9,7 @@ import (
 	"hash"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -24,6 +25,12 @@ type Mux struct {
 type muxEntry struct {
 	prefix  bool
 	handler http.Handler
+	methods []string
+}
+
+type muxError struct {
+	code    int
+	message string
 }
 
 // NewMux makes a new empty Mux.
@@ -41,18 +48,18 @@ func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	handler, ok := mux.lookup(r.URL.Path)
-	if !ok {
-		http.NotFound(w, r)
+	handler, err := mux.lookup(r.Method, r.URL.Path)
+	if err != nil {
+		http.Error(w, err.message, err.code)
 		return
 	}
 
 	handler.ServeHTTP(w, r)
 }
 
-// lookup takes a path and looks up its registered entry in the mux trie,
+// lookup takes a method and path and looks up its registered entry in the mux trie,
 // returning the handler for that path, if any matches.
-func (mux *Mux) lookup(path string) (handler http.Handler, ok bool) {
+func (mux *Mux) lookup(method string, path string) (http.Handler, *muxError) {
 	mux.mu.RLock()
 	defer mux.mu.RUnlock()
 
@@ -61,35 +68,43 @@ func (mux *Mux) lookup(path string) (handler http.Handler, ok bool) {
 	if !ok {
 		val, ok = mux.prefixTrie.GetLongestPrefix(pathSegments)
 	}
+
 	if !ok {
-		return nil, false
+		return nil, &muxError{ code: http.StatusNotFound, message: "404 Not Found" }
 	}
 
 	entry, ok := val.(muxEntry)
 	if !ok {
 		log.Printf("lookup: got value (%v) from trie that wasn't a muxEntry!", val)
-		return nil, false
+		return nil, &muxError{ code: http.StatusInternalServerError, message: "500 Internal Server Error" }
 	}
 
-	return entry.handler, ok
+	if !entry.methodSupported(method) {
+		return nil, &muxError{ code: http.StatusMethodNotAllowed, message: "405 Method Not Allowed" }
+	}
+
+	return entry.handler, nil
 }
 
 // Handle registers the specified route (either an exact or a prefix route)
 // and associates it with the specified handler. Requests through the mux for
 // paths matching the route will be passed to that handler.
-func (mux *Mux) Handle(path string, prefix bool, handler http.Handler) {
+func (mux *Mux) Handle(path string, methods []string, prefix bool, handler http.Handler) {
 	mux.mu.Lock()
 	defer mux.mu.Unlock()
 
-	mux.addToStats(path, prefix)
+	// For faster lookups and consistent checksums
+	sort.Strings(methods)
+
+	mux.addToStats(path, prefix, methods)
 	if prefix {
-		mux.prefixTrie.Set(splitpath(path), muxEntry{prefix, handler})
+		mux.prefixTrie.Set(splitpath(path), muxEntry{prefix, handler, methods})
 	} else {
-		mux.exactTrie.Set(splitpath(path), muxEntry{prefix, handler})
+		mux.exactTrie.Set(splitpath(path), muxEntry{prefix, handler, methods})
 	}
 }
 
-func (mux *Mux) addToStats(path string, prefix bool) {
+func (mux *Mux) addToStats(path string, prefix bool, methods []string) {
 	mux.count++
 	mux.checksum.Write([]byte(path))
 	if prefix {
@@ -97,6 +112,7 @@ func (mux *Mux) addToStats(path string, prefix bool) {
 	} else {
 		mux.checksum.Write([]byte("(false)"))
 	}
+	mux.checksum.Write([]byte(strings.Join(methods,",")))
 }
 
 func (mux *Mux) RouteCount() int {
@@ -105,6 +121,21 @@ func (mux *Mux) RouteCount() int {
 
 func (mux *Mux) RouteChecksum() []byte {
 	return mux.checksum.Sum(nil)
+}
+
+func (e muxEntry) methodSupported(method string) bool {
+	if len(e.methods) == 0 {
+		// If routes don't specify the methods they allow, we assume they
+		// allow all methods.
+		return true
+	}
+	return contains(e.methods, method)
+}
+
+// contains searches a sorted list efficiently using the sort package
+func contains(sortedStrings []string, s string) bool {
+	i := sort.SearchStrings(sortedStrings, s)
+	return i < len(sortedStrings) && sortedStrings[i] == s
 }
 
 // splitpath turns a slash-delimited string into a lookup path (a slice


### PR DESCRIPTION
**Note**: This is not yet ready for merge.

This adds optional methods to routes, allowing us to specify the routes that should be accepted by a path.

For example, on GOV.UK 'GET /' is acceptable but 'DELETE /' is not. We know this, so we can return a 405 at the router level, rather than letting our slower applications handle this request downstream of router.

Further work will need to be done, first on Router API to support path methods, then on content store, publishing-api and the publishing apps.

Router API should set a default empty array for all routes, or nil, which will permit all methods to be accepted. Router API should also allow HEAD should a GET method be allowed.

I'd be grateful for feedback on the router implementation, and thoughts about the approach more generally. Let me know if you have any questions!

https://trello.com/c/v9exwjls/1406-spike-implement-request-method-handling-in-router

----

@kevindew here adding some adding context for this work. The work Bill has put together is a spike exploring the hypothesis that for requests with the wrong HTTP method it would be a lower performance cost to have them returned directly from Router rather than having the request be proxied to the app to then return a 404/405 response. This is an alternative approach to [caching 404/405 POST requests at the CDN](https://github.com/alphagov/govuk-cdn-config/pull/160) which suffered the problem that cache entries were unable to be purged and felt, to us, like an unconventional usage of varnish.

The idea we had was that we could [specify in Router API which methods are accepted](https://github.com/alphagov/router-api/commit/9fa4f3d31694ae95da25987f5609462bd32281ab) for a route, with GET being the default if no method provided and HEAD implicitly supported wherever GET is available. The expectation is then that whenever GOV.UK apps register routes they could specify if they wanted routes beyond GET. This would involve a [schema change](https://github.com/alphagov/govuk-content-schemas/commit/53f68f27d9c830aef32ad6ea930a66a402a6b42e) and [Content Store passing the methods to Router API](https://github.com/alphagov/content-store/commit/f50908c9cdd10402171bb11e88b5537113698510).

The next step would be to then change all of the GOV.UK routes that accept non-GET requests (which, as far as I can tell, is only POST requests) [to also accept POST requests](https://github.com/alphagov/email-alert-frontend/commit/2c1a04fd790e3cb1c84cc5d2e65fd32b582ff63d). I think I managed to identify most from CDN logs and config/routes.rb files, however there were more than I anticipated, more prefix ones than expected and I'm not super confident I caught them all.

- Email Alert Frontend sets it's own POST prefix paths of /email-signup, /email/manage, /email/subscriptions and /email/unsubscribe. It also serves /*base-path/email-signup paths set by the following apps: [Search API](https://github.com/alphagov/search-api/blob/00a56065dac50d377c9bcd76b233e605f08cc868/lib/tasks/publishing_api.rake#L48), [Travel Advice Publisher](https://github.com/alphagov/travel-advice-publisher/blob/e291b61198f0587887438e72f654181068ddbae5/lib/tasks/publishing_api.rake#L103-L115), [Specialist Publisher](https://github.com/alphagov/specialist-publisher/blob/0e12ff7e36765719294e725129d2c1e1abef62a4/lib/publishing_api_finder_publisher.rb#L55-L58), [Service Manual Publisher](https://github.com/alphagov/service-manual-publisher/blob/432dc8072ffe33578b6ce43039fc9b97adf0bea3/app/presenters/service_standard_email_alert_signup_presenter.rb#L26-L31) and [Special Route Publisher](https://github.com/alphagov/special-route-publisher/blob/0e0bfa8fdf9aef998a86601ac787c87aadc173f0/data/special_routes.yaml#L18-L21)
- Frontend has [/find-local-council](https://github.com/alphagov/frontend/blob/0dcd33bb994e743eab94f34911656163c3678258/lib/special_route_publisher.rb#L21). It also has a lot of [/brexit-funding URLs](https://github.com/alphagov/frontend/blob/0dcd33bb994e743eab94f34911656163c3678258/config/routes.rb#L26-L46) which may no longer be in use.
- Publisher would need to set POST routes for [local transaction, place and licence document types](https://github.com/alphagov/frontend/blob/0dcd33bb994e743eab94f34911656163c3678258/config/routes.rb#L66-L85). It also sets a [/*path/service-sign-in](https://github.com/alphagov/publisher/blob/404862d6fdcd2b5ae939dc13441215a9b4bd066d/app/presenters/formats/service_sign_in_presenter.rb#L58) which [government-frontend accepts as a POST](https://github.com/alphagov/government-frontend/blob/7bd03d3e521c373464758bbcf19d3f94ae526bf6/config/routes.rb#L25)
- Contacts publishes [routes that accept POST on /contact/govuk/*](https://github.com/alphagov/feedback/blob/eab6a4659e1ad711f83e3ce39b7c89e3ad59c389/lib/tasks/publishing_api.rake#L63-L70)
- Licensify seems to have a /apply-for-a-licence prefix route that isn't registered in Content Store

Once these are all changed then the default of GET could be set. 

Bill and I have decided to pause work on this as we felt the next step would be an RFC and we struggled to justify the value of this work relative to the effort. We felt it was perhaps too niche a problem to solve. If this is picked up later we think the next step is do some load testing with router to test the hypothesis that this will allow a much greater number of requests to be served with Router better equipped to determine if they are erroneous without proxying.