### PR TITLE
Adds a test to demonstrate encoded path matching

### DIFF
--- a/integration_tests/route_selection_test.go
+++ b/integration_tests/route_selection_test.go
@@ -155,6 +155,23 @@ var _ = Describe("Route selection", func() {
 			})
 		})
 
+		Describe("url encoded paths", func() {
+			BeforeEach(func() {
+				addRoute("/foo/bar", NewBackendRoute("inner-backend"))
+				reloadRoutes()
+			})
+
+			It("should route the prefix to the outer backend", func() {
+				resp := routerRequest("/foo")
+				Expect(readBody(resp)).To(Equal("outer"))
+			})
+
+			It("should route the exact child to the inner backend", func() {
+				resp := routerRequest("/foo%2Fbar")
+				Expect(readBody(resp)).To(Equal("inner"))
+			})
+		})
+
 		Describe("with a prefix child", func() {
 			BeforeEach(func() {
 				addRoute("/foo/bar", NewBackendRoute("inner-backend", "prefix"))


### PR DESCRIPTION
This is a copy / tweak of existing tests and demonstrates that router routes things that are URL encoded.

At least one of our frontend apps is not built to handle URL encoded paths and [errors under some circumstances](https://sentry.io/organizations/govuk/issues/1399727649/?project=202213&query=is%3Aunresolved).  [A sort of fix has been implemented for collections](https://github.com/alphagov/collections/pull/1533).

Should we "fix" router to not behave like this?

Related stack overflows are seem inconclusive - for example Apache allows you to toggle a setting that allows this. 
- https://stackoverflow.com/questions/3235219/urlencoded-forward-slash-is-breaking-url
- https://stackoverflow.com/questions/1957115/is-a-slash-equivalent-to-an-encoded-slash-2f-in-the-path-portion-of-a?

