### PR TITLE
Makefile "make test" uses go list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	go build -ldflags "-X main.version=$(VERSION)" -o $(BINARY)
 
 test: build
-	go test -race ./trie ./triemux ./handlers
+	go test -race $$(go list ./... | grep -v integration_tests)
 	go test -race -v ./integration_tests
 
 run: build


### PR DESCRIPTION
What
----

Change `make test` to use `go list`

Why
----

I interpret the intention of `make test` to:
* run all tests except the integration tests
* run the integration tests verbosely

The original "go test -race ./trie ./triemux ./handlers" command missed out on the logger package (although there are no tests in logger)

"go list ./..." recursively lists all packages in the current directory

Using go list in the make task means that if there is a refactoring, and a new package is added, or a package is renamed, the intended tests will still run

How to review
----

Review CI output resembles:

```
make test
go build -ldflags "-X main.version=release_212-1-g727af70-dirty" -o /Users/tobylornewelchrichards/Code/router/router
go test -race -count=1 $(go list ./... | grep -v integration_tests)
?   	github.com/alphagov/router	[no test files]
ok  	github.com/alphagov/router/handlers	10.776s
?   	github.com/alphagov/router/logger	[no test files]
ok  	github.com/alphagov/router/trie	0.040s
ok  	github.com/alphagov/router/triemux	0.047s
go test -race -v ./integration_tests
=== RUN   TestEverything
Running Suite: Integration test suite
=====================================
Random Seed: 1603961314
Will run 105 of 107 specs
...
```