### PR TITLE
Adjust histogram buckets for faster responses

### DIFF
--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -33,7 +33,7 @@ var (
 			Name: "router_backend_handler_response_duration_seconds",
 			Help: "Histogram of response durations by router backend handlers",
 			Buckets: prometheus.ExponentialBuckets(
-				0.25, 2, 6, // This buckets [...0.25  0.5  1  2  4  8...]
+				0.0625, 2, 7, // This buckets [...0.0625  0.125  0.25  0.5  1  2  4...]
 			),
 		},
 		[]string{

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -32,9 +32,6 @@ var (
 		prometheus.HistogramOpts{
 			Name: "router_backend_handler_response_duration_seconds",
 			Help: "Histogram of response durations by router backend handlers",
-			Buckets: prometheus.ExponentialBuckets(
-				0.0625, 2, 7, // This buckets [...0.0625  0.125  0.25  0.5  1  2  4...]
-			),
 		},
 		[]string{
 			"backend_id",


### PR DESCRIPTION
At the moment, router's metrics bucket response times into:

* Less than 250ms
* 250ms - 500ms
* 500ms - 1s
* 1s - 2s
* 2s - 4s
* 4s - 8s
* More than 8s

From looking at our metrics, the majority of our responses complete in
less than 250ms, so this is not a particularly useful distribution.

By starting the exponential buckets at 1/16 of a second instead of 1/4
we should get a much more useful view of the latency distribution.

I've added one more bucket, so we can still see the 2-4 second range.
Responses that take more than 4 seconds should just be considered as
"very slow", so losing the "more than 8 seconds" bucket isn't really a
problem.

## Context

I've been trying to visualise this histogram as a heatmap in Grafana. At the moment it looks like this:

![image](https://user-images.githubusercontent.com/1696784/104292107-531a2180-54b4-11eb-9c04-e4eb280c688f.png)

All the interesting stuff is happening in that 0-250ms bucket, which suggests we could do with splitting that bucket up a bit. Hardly any requests take more than 4secs.