### PR TITLE
Update routes within router

### DIFF
--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -53,6 +53,7 @@ func startRouter(port, apiPort int, optionalExtraEnv ...envMap) error {
 	env["ROUTER_PUBADDR"] = pubaddr
 	env["ROUTER_APIADDR"] = apiaddr
 	env["ROUTER_MONGO_DB"] = "router_test"
+	env["ROUTER_MONGO_POLL_INTERVAL"] = "2s"
 	env["ROUTER_ERROR_LOG"] = tempLogfile.Name()
 	if len(optionalExtraEnv) > 0 {
 		for k, v := range optionalExtraEnv[0] {

--- a/router_api.go
+++ b/router_api.go
@@ -12,16 +12,6 @@ func newAPIHandler(rout *Router) (api http.Handler, err error) {
 	if err != nil {
 		return nil, err
 	}
-	reloadChan := make(chan bool, 1)
-	go func(r chan bool) {
-		// This goroutine blocks until it receives a message on reloadChan,
-		// and will immediately reload again if another message was received
-		// during reload.
-		for range r {
-			logInfo("router: reload triggered")
-			rout.ReloadRoutes()
-		}
-	}(reloadChan)
 
 	mux := http.NewServeMux()
 
@@ -31,11 +21,12 @@ func newAPIHandler(rout *Router) (api http.Handler, err error) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		// Send a message to the goroutine which will start reloading immediately.
+		// Send a message to the Router goroutine which will check the latest
+		// oplog optime and start a reload if necessary.
 		// If the channel is already full, no message will be sent and the request
 		// won't be blocked.
 		select {
-		case reloadChan <- true:
+		case rout.ReloadChan <- true:
 		default:
 		}
 		logInfo("router: reload queued")

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/globalsign/mgo/bson"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type mockMongoDB struct {
+	result bson.M
+	err error
+}
+
+func (m *mockMongoDB) Run(cmd interface{}, res interface{}) error {
+	if m.err != nil {
+		return m.err
+	} else {
+		bytes, err := bson.Marshal(m.result)
+		if err != nil {
+			return err
+		}
+
+		err = bson.Unmarshal(bytes, res)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestRouter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Router Suite")
+}
+
+var _ = Describe("Router", func() {
+	Context("When calling shouldReload", func() {
+		Context("with an up-to-date mongo instance", func() {
+			It("should return false", func() {
+				rt := Router{}
+				initialOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 1)
+				rt.mongoReadToOptime = initialOptime
+
+				currentOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 1)
+				mongoInstance := MongoReplicaSetMember{}
+				mongoInstance.Optime = currentOptime
+
+				Expect(rt.shouldReload(mongoInstance)).To(
+					Equal(false),
+					"Router should determine no reload is necessary when Mongo optime hasn't changed",
+				)
+			})
+		})
+
+		Context("with a stale mongo instance", func() {
+			It("should return false when timestamp differs", func() {
+				rt := Router{}
+				initialOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 1)
+				rt.mongoReadToOptime = initialOptime
+				
+				currentOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 2, 30, 0, time.UTC), 1)
+				mongoInstance := MongoReplicaSetMember{}
+				mongoInstance.Optime = currentOptime
+
+				Expect(rt.shouldReload(mongoInstance)).To(
+					Equal(true),
+					"Router should determine reload is necessary when Mongo optime has changed by timestamp",
+				)
+			})
+
+			It("should return false when operand differs", func() {
+				rt := Router{}
+				initialOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 1)
+				rt.mongoReadToOptime = initialOptime
+				
+				currentOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 2)
+				mongoInstance := MongoReplicaSetMember{}
+				mongoInstance.Optime = currentOptime
+
+				Expect(rt.shouldReload(mongoInstance)).To(
+					Equal(true),
+					"Router should determine reload is necessary when Mongo optime has changed by operand",
+				)
+			})
+		})
+	})
+
+	Context("When calling getCurrentMongoInstance", func() {
+		It("should return error when unable to get the replica set", func() {
+			mockMongoObj := &mockMongoDB{
+				err: errors.New("Error connecting to replica set"),
+			}
+
+			rt := Router{}
+			_, err := rt.getCurrentMongoInstance(mockMongoObj)
+
+			Expect(err).NotTo(
+				BeNil(), 
+				"Router should raise an error when it can't get replica set status from Mongo")
+		})
+
+		It("should return fail to find an instance when the replica set status schema doesn't match the expected schema", func() {
+			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"unknownProperty": "unknown"}}}
+			mockMongoObj := &mockMongoDB{
+				result: replicaSetStatusBson,
+			}
+
+			rt := Router{}
+			_, err := rt.getCurrentMongoInstance(mockMongoObj)
+
+			Expect(err).NotTo(
+				BeNil(), 
+				"Router should raise an error when the current Mongo instance can't be found in the replica set status response")
+		})
+
+		It("should return fail to find an instance when the replica set status contains no instances marked with self:true", func() {
+			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"name": "mongo1", "self": false}}}
+			mockMongoObj := &mockMongoDB{
+				result: replicaSetStatusBson,
+			}
+
+			rt := Router{}
+			_, err := rt.getCurrentMongoInstance(mockMongoObj)
+
+			Expect(err).NotTo(
+				BeNil(), 
+				"Router should raise an error when the current Mongo instance can't be found in the replica set status response")
+		})
+
+		It("should return fail to find an instance when the replica set status contains multiple instances marked with self:true", func() {
+			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"name": "mongo1", "self": true}, bson.M{"name": "mongo2", "self": true}}}
+			mockMongoObj := &mockMongoDB{
+				result: replicaSetStatusBson,
+			}
+
+			rt := Router{}
+			_, err := rt.getCurrentMongoInstance(mockMongoObj)
+
+			Expect(err).NotTo(
+				BeNil(), 
+				"Router should raise an error when the replica set status response contains multiple current Mongo instances")
+		})
+
+		It("should successfully return the current Mongo instance from the replica set", func() {
+			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"name": "mongo1", "self": false}, bson.M{"name": "mongo2", "optime": 6945383634312364034, "self": true}}}
+			mockMongoObj := &mockMongoDB{
+				result: replicaSetStatusBson,
+			}
+
+			expectedMongoInstance := MongoReplicaSetMember{
+				Name: "mongo2",
+				Optime: 6945383634312364034,
+				Current: true,
+			}
+
+			rt := Router{}
+			currentMongoInstance, _ := rt.getCurrentMongoInstance(mockMongoObj)
+
+			Expect(currentMongoInstance).To(
+				Equal(expectedMongoInstance),
+				"Router should get the current Mongo instance from the replica set status response",
+			)
+		})
+	})		
+})


### PR DESCRIPTION
This PR adds functionality to Router so that it takes charge of updating its own routes, polling MongoDB every 30 seconds to check for changes and performing the swapping of route tables if updates are found to have occurred. This change takes place at the same time as we stop requests being sent by Router API to force updates to Router instances, allowing us to decouple these apps and make it far easier to run in ECS (as Router API no longer needs to know where to find Router instances).

[For more information around these changes, view RFC 135](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-135-updating-routes-in-router.md).