### PR TITLE
Use cmd, not entrypoint, in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,4 @@ ENV ROUTER_APIADDR :3055
 ENV ROUTER_MONGO_URL mongo
 ENV ROUTER_MONGO_DB router
 ENV DEBUG true
-ENTRYPOINT ["/bin/router"]
-CMD []
+CMD ["/bin/router"]


### PR DESCRIPTION
This makes the router image consistent with other GOV.UK Docker images.

If an image specifies an `ENTRYPOINT`, then the `CMD` or `COMMAND` get appended as arguments to the `ENTRYPOINT` when running the container.

For example, `docker run govuk/router /bin/sh -c exit 0` would start the router app (passing `/bin/sh ...` as an arg to `/bin/router`), rather than exiting as expected.

Entrypoint is similar to command since it specifies what executable to run when the container starts. However, entrypoint is purposefully more difficult to override.

Also, since we are bringing up Router in ECS, it would be good for this image to be similar to the others we're running. Though, [Entrypoint is supported by ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#standard_container_definition_params).