### PR TITLE
Increase StartupDelay during deployments

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/alext/tablecloth"
 	"github.com/alphagov/router/handlers"
@@ -75,6 +76,7 @@ func logDebug(msg ...interface{}) {
 
 func catchListenAndServe(addr string, handler http.Handler, ident string, wg *sync.WaitGroup) {
 	defer wg.Done()
+	tablecloth.StartupDelay = 60 * time.Second
 	err := tablecloth.ListenAndServe(addr, handler, ident)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
#### Motivation

We see 503 errors when deploying router - this change hopes to reduce the number of errors we see.

The Router child process is returning a 503 error during deploys since the child process routing table is still empty when it receives its first request. We have recently started monitoring this error case: https://sentry.io/organizations/govuk/issues/2311515746/.

I think the routing table is taking longer to populate as more routes are added. 5 seconds may have been sufficient time to wait for the child process to get 'hot' in the past, but it now needs a bit longer.

#### Implementation

This overrides [the default startup delay](https://github.com/alext/tablecloth/blob/9a28c0f651e7faeb01e0381f263d1ad273cfc188/manager.go#L20) set in the Tablecloth library.

This is a small patch rather than fixing the underlying issue. The more robust fix will come when we move to hosting router in ECS, where we'll do blue-green deploys and remove the Tablecloth dependency.

I experimented deploying with a startup delay of both 30s and then 60s, and we see fewer errors when waiting for 60s. The chart below shows 503 errors served by staging cache machine's Nginx during deploys (deploy start times indicated by the green annotations):

<img width="1421" alt="Screenshot 2021-04-27 at 15 16 32" src="https://user-images.githubusercontent.com/8124374/116257603-15dc5580-a76c-11eb-855c-0ced75f77c4b.png">

Please note that we won't see the benefit of this change until _after_ it is deployed. We'll still see the same error rate the next time we deploy.