### PR TITLE
Remove disused checksum feature

### DIFF
--- a/integration_tests/performance_test.go
+++ b/integration_tests/performance_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Performance", func() {
 		}
 	})
 
-	Describe("many concurrent (slow) connectons", func() {
+	Describe("many concurrent (slow) connections", func() {
 		if os.Getenv("RUN_ULIMIT_DEPENDENT_TESTS") != "" {
 			var (
 				backend1 *httptest.Server

--- a/integration_tests/reload_api_test.go
+++ b/integration_tests/reload_api_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"crypto/sha1"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -89,14 +87,6 @@ var _ = Describe("reload API endpoint", func() {
 			It("should return the number of routes loaded", func() {
 				Expect(data["routes"]["count"]).To(BeEquivalentTo(3))
 			})
-
-			It("should return a checksum calculated from the sorted paths and route_types", func() {
-				hash := sha1.New()
-				hash.Write([]byte("/baz(true)"))
-				hash.Write([]byte("/foo(false)"))
-				hash.Write([]byte("/foo(true)"))
-				Expect(data["routes"]["checksum"]).To(Equal(fmt.Sprintf("%x", hash.Sum(nil))))
-			})
 		})
 
 		Context("with no routes", func() {
@@ -112,11 +102,6 @@ var _ = Describe("reload API endpoint", func() {
 
 			It("should return the number of routes loaded", func() {
 				Expect(data["routes"]["count"]).To(BeEquivalentTo(0))
-			})
-
-			It("should return a checksum of empty string", func() {
-				hash := sha1.New()
-				Expect(data["routes"]["checksum"]).To(Equal(fmt.Sprintf("%x", hash.Sum(nil))))
 			})
 		})
 

--- a/router.go
+++ b/router.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -237,18 +236,18 @@ func (rt *Router) getCurrentMongoInstance(db mongoDatabase) (MongoReplicaSetMemb
 	replicaSetStatus := bson.M{}
 
 	if err := db.Run("replSetGetStatus", &replicaSetStatus); err != nil {
-		return MongoReplicaSetMember{}, errors.New(fmt.Sprintf("router: couldn't get replica set status from MongoDB, skipping update (error: %v)", err))
+		return MongoReplicaSetMember{}, fmt.Errorf("router: couldn't get replica set status from MongoDB, skipping update (error: %v)", err)
 	}
 
 	replicaSetStatusBytes, err := bson.Marshal(replicaSetStatus)
 	if err != nil {
-		return MongoReplicaSetMember{}, errors.New(fmt.Sprintf("router: couldn't marshal replica set status from MongoDB, skipping update (error: %v)", err))
+		return MongoReplicaSetMember{}, fmt.Errorf("router: couldn't marshal replica set status from MongoDB, skipping update (error: %v)", err)
 	}
 
 	replicaSet := MongoReplicaSet{}
 	err = bson.Unmarshal(replicaSetStatusBytes, &replicaSet)
 	if err != nil {
-		return MongoReplicaSetMember{}, errors.New(fmt.Sprintf("router: couldn't unmarshal replica set status from MongoDB, skipping update (error: %v)", err))
+		return MongoReplicaSetMember{}, fmt.Errorf("router: couldn't unmarshal replica set status from MongoDB, skipping update (error: %v)", err)
 	}
 
 	currentInstance := make([]MongoReplicaSetMember, 0)
@@ -261,7 +260,7 @@ func (rt *Router) getCurrentMongoInstance(db mongoDatabase) (MongoReplicaSetMemb
 	logDebug("router: MongoDB instances", currentInstance)
 
 	if len(currentInstance) != 1 {
-		return MongoReplicaSetMember{}, errors.New(fmt.Sprintf("router: did not find exactly one current MongoDB instance, skipping update (current instances found: %d)", len(currentInstance)))
+		return MongoReplicaSetMember{}, fmt.Errorf("router: did not find exactly one current MongoDB instance, skipping update (current instances found: %d)", len(currentInstance))
 	}
 
 	return currentInstance[0], nil

--- a/router.go
+++ b/router.go
@@ -227,7 +227,7 @@ func (rt *Router) reloadRoutes(db *mgo.Database, currentOptime bson.MongoTimesta
 	rt.mux = newmux
 	rt.lock.Unlock()
 
-	logInfo(fmt.Sprintf("router: reloaded %d routes (checksum: %x)", rt.mux.RouteCount(), rt.mux.RouteChecksum()))
+	logInfo(fmt.Sprintf("router: reloaded %d routes", rt.mux.RouteCount()))
 
 	routesCountMetric.Set(float64(rt.mux.RouteCount()))
 }
@@ -307,7 +307,7 @@ func (rt *Router) loadBackends(c *mgo.Collection) (backends map[string]http.Hand
 func loadRoutes(c *mgo.Collection, mux *triemux.Mux, backends map[string]http.Handler) {
 	route := &Route{}
 
-	iter := c.Find(nil).Sort("incoming_path", "route_type").Iter()
+	iter := c.Find(nil).Iter()
 
 	goneHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "410 Gone", http.StatusGone)
@@ -386,7 +386,6 @@ func (rt *Router) RouteStats() (stats map[string]interface{}) {
 
 	stats = make(map[string]interface{})
 	stats["count"] = mux.RouteCount()
-	stats["checksum"] = fmt.Sprintf("%x", mux.RouteChecksum())
 	return
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -13,7 +13,7 @@ import (
 
 type mockMongoDB struct {
 	result bson.M
-	err error
+	err    error
 }
 
 func (m *mockMongoDB) Run(cmd interface{}, res interface{}) error {
@@ -63,7 +63,7 @@ var _ = Describe("Router", func() {
 				rt := Router{}
 				initialOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 1)
 				rt.mongoReadToOptime = initialOptime
-				
+
 				currentOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 2, 30, 0, time.UTC), 1)
 				mongoInstance := MongoReplicaSetMember{}
 				mongoInstance.Optime = currentOptime
@@ -78,7 +78,7 @@ var _ = Describe("Router", func() {
 				rt := Router{}
 				initialOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 1)
 				rt.mongoReadToOptime = initialOptime
-				
+
 				currentOptime, _ := bson.NewMongoTimestamp(time.Date(2021, time.March, 12, 8, 0, 0, 0, time.UTC), 2)
 				mongoInstance := MongoReplicaSetMember{}
 				mongoInstance.Optime = currentOptime
@@ -101,12 +101,12 @@ var _ = Describe("Router", func() {
 			_, err := rt.getCurrentMongoInstance(mockMongoObj)
 
 			Expect(err).NotTo(
-				BeNil(), 
+				BeNil(),
 				"Router should raise an error when it can't get replica set status from Mongo")
 		})
 
 		It("should return fail to find an instance when the replica set status schema doesn't match the expected schema", func() {
-			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"unknownProperty": "unknown"}}}
+			replicaSetStatusBson := bson.M{"members": []bson.M{{"unknownProperty": "unknown"}}}
 			mockMongoObj := &mockMongoDB{
 				result: replicaSetStatusBson,
 			}
@@ -115,12 +115,12 @@ var _ = Describe("Router", func() {
 			_, err := rt.getCurrentMongoInstance(mockMongoObj)
 
 			Expect(err).NotTo(
-				BeNil(), 
+				BeNil(),
 				"Router should raise an error when the current Mongo instance can't be found in the replica set status response")
 		})
 
 		It("should return fail to find an instance when the replica set status contains no instances marked with self:true", func() {
-			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"name": "mongo1", "self": false}}}
+			replicaSetStatusBson := bson.M{"members": []bson.M{{"name": "mongo1", "self": false}}}
 			mockMongoObj := &mockMongoDB{
 				result: replicaSetStatusBson,
 			}
@@ -129,12 +129,12 @@ var _ = Describe("Router", func() {
 			_, err := rt.getCurrentMongoInstance(mockMongoObj)
 
 			Expect(err).NotTo(
-				BeNil(), 
+				BeNil(),
 				"Router should raise an error when the current Mongo instance can't be found in the replica set status response")
 		})
 
 		It("should return fail to find an instance when the replica set status contains multiple instances marked with self:true", func() {
-			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"name": "mongo1", "self": true}, bson.M{"name": "mongo2", "self": true}}}
+			replicaSetStatusBson := bson.M{"members": []bson.M{{"name": "mongo1", "self": true}, {"name": "mongo2", "self": true}}}
 			mockMongoObj := &mockMongoDB{
 				result: replicaSetStatusBson,
 			}
@@ -143,19 +143,19 @@ var _ = Describe("Router", func() {
 			_, err := rt.getCurrentMongoInstance(mockMongoObj)
 
 			Expect(err).NotTo(
-				BeNil(), 
+				BeNil(),
 				"Router should raise an error when the replica set status response contains multiple current Mongo instances")
 		})
 
 		It("should successfully return the current Mongo instance from the replica set", func() {
-			replicaSetStatusBson := bson.M{"members": []bson.M{bson.M{"name": "mongo1", "self": false}, bson.M{"name": "mongo2", "optime": 6945383634312364034, "self": true}}}
+			replicaSetStatusBson := bson.M{"members": []bson.M{{"name": "mongo1", "self": false}, {"name": "mongo2", "optime": 6945383634312364034, "self": true}}}
 			mockMongoObj := &mockMongoDB{
 				result: replicaSetStatusBson,
 			}
 
 			expectedMongoInstance := MongoReplicaSetMember{
-				Name: "mongo2",
-				Optime: 6945383634312364034,
+				Name:    "mongo2",
+				Optime:  6945383634312364034,
 				Current: true,
 			}
 
@@ -167,5 +167,5 @@ var _ = Describe("Router", func() {
 				"Router should get the current Mongo instance from the replica set status response",
 			)
 		})
-	})		
+	})
 })

--- a/triemux/mux.go
+++ b/triemux/mux.go
@@ -43,11 +43,13 @@ func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if mux.count == 0 {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		logger.NotifySentry(logger.ReportableError{
-			Error: logger.RecoveredError{"Route table is empty!"},
+			Error:   logger.RecoveredError{ErrorMessage: "Route table is empty!"},
 			Request: r,
 		})
 		tempChild, isParent := os.LookupEnv("TEMPORARY_CHILD")
-		if !isParent { tempChild = "0" }
+		if !isParent {
+			tempChild = "0"
+		}
 		InternalServiceUnavailableCountMetric.With(prometheus.Labels{
 			"temporary_child": tempChild,
 		}).Inc()

--- a/triemux/mux_test.go
+++ b/triemux/mux_test.go
@@ -1,8 +1,6 @@
 package triemux
 
 import (
-	"crypto/sha1"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -231,20 +229,6 @@ func TestRouteCount(t *testing.T) {
 	actual := mux.RouteCount()
 	if actual != 3 {
 		t.Errorf("Expected count to be 3, was %d", actual)
-	}
-}
-
-func TestChecksum(t *testing.T) {
-	mux := NewMux()
-	hash := sha1.New()
-	for _, reg := range statsExample {
-		mux.Handle(reg.path, reg.prefix, reg.handler)
-		hash.Write([]byte(fmt.Sprintf("%s(%v)", reg.path, reg.prefix)))
-	}
-	expected := fmt.Sprintf("%x", hash.Sum(nil))
-	actual := fmt.Sprintf("%x", mux.RouteChecksum())
-	if expected != actual {
-		t.Errorf("Expected checksum to be %s, was %s", expected, actual)
 	}
 }
 


### PR DESCRIPTION
This essentially reverts #56.

AFAICT the checksum is not used anywhere (even in monitoring), but it recently started causing a real problem because it's asking MongoDB to sort the routes collection.  Apart from being inefficient, this runs into a scaling limitation of Mongo and led to route reloads failing under certain circumstances with errors like `Runner error during find: Overflow sort stage buffered data usage of 33554700 bytes exceeds internal limit of 33554432 bytes`.

We could alternatively add indices on those fields, but it's much better to remove the disused feature. This way we reduce the maintenance burden and maybe improve scalability a bit by eliminating unnecessary work on reloads.

Tested: Ran the testsuite locally:
```
$ make test_with_docker
...
Ran 103 of 106 Specs in 58.293 seconds
SUCCESS! -- 103 Passed | 0 Failed | 2 Pending | 1 Skipped
--- PASS: TestEverything (58.36s)
PASS
ok  	github.com/alphagov/router/integration_tests	58.710s
```

The `2 Pending | 1 Skipped` are the same with and without this change ("high throughput requires elevated ulimit", "connect timeout requires firewall block rule" and "should contain router internal server error metrics", respectively - all unrelated to this change).

The publishing-e2e-tests failure seems unrelated (`Container(s) finder-frontend were unhealthy after 60 seconds`).

[Trello card](https://trello.com/c/u0Grszrz/500)