### PR TITLE
Fix cardinality of router_redirect_handler_redirect_total metric.

### DIFF
--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -13,7 +13,6 @@ var (
 		[]string{
 			"redirect_code",
 			"redirect_type",
-			"redirect_url",
 		},
 	)
 

--- a/handlers/redirect_handler.go
+++ b/handlers/redirect_handler.go
@@ -62,9 +62,8 @@ func (handler *redirectHandler) ServeHTTP(writer http.ResponseWriter, request *h
 	http.Redirect(writer, request, target, handler.code)
 
 	RedirectHandlerRedirectCountMetric.With(prometheus.Labels{
-		"redirect_type": redirectHandlerType,
 		"redirect_code": fmt.Sprintf("%d", handler.code),
-		"redirect_url":  handler.url,
+		"redirect_type": redirectHandlerType,
 	}).Inc()
 }
 
@@ -87,14 +86,5 @@ func (handler *pathPreservingRedirectHandler) ServeHTTP(writer http.ResponseWrit
 	RedirectHandlerRedirectCountMetric.With(prometheus.Labels{
 		"redirect_code": fmt.Sprintf("%d", handler.code),
 		"redirect_type": pathPreservingRedirectHandlerType,
-		"redirect_url":  stripQuery(target),
 	}).Inc()
-}
-
-// stripQuery should only be called with valid URL
-// stripQuery should only be used for recording the URL used by the handler
-func stripQuery(us string) string {
-	u, _ := url.Parse(us)
-	u.RawQuery = ""
-	return u.String()
 }

--- a/handlers/redirect_handler_test.go
+++ b/handlers/redirect_handler_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Redirect handlers", func() {
 			var (
 				redirectCode string
 				redirectType string
-				redirectURL  string
 			)
 
 			if t.temporary {
@@ -64,16 +63,13 @@ var _ = Describe("Redirect handlers", func() {
 
 			if t.preserve {
 				redirectType = "path-preserving-redirect-handler"
-				redirectURL = "/target-prefix/path/subpath"
 			} else {
 				redirectType = "redirect-handler"
-				redirectURL = "/target-prefix"
 			}
 
 			labels := prometheus.Labels{
 				"redirect_code": redirectCode,
 				"redirect_type": redirectType,
-				"redirect_url":  redirectURL,
 			}
 
 			beforeCount := promtest.ToFloat64(
@@ -204,7 +200,6 @@ var _ = Describe("Redirect handlers", func() {
 				labels := prometheus.Labels{
 					"redirect_code": "302",
 					"redirect_type": "redirect-handler",
-					"redirect_url":  "/target-prefix",
 				}
 
 				beforeCount := promtest.ToFloat64(


### PR DESCRIPTION
This was OOMing Prometheus in prod and using taking up most of the long-term storage.

The fix is not to try to include the redirect URL as a label. Prometheus isn't designed for such high-cardinality metrics.

Tested: `Ran 103 of 106 Specs in 59.253 seconds` `SUCCESS! -- 103 Passed | 0 Failed | 2 Pending | 1 Skipped`