### PR TITLE
Set the default header timeout to what we're actually using everywhere.

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var (
 	tlsSkipVerify         = os.Getenv("ROUTER_TLS_SKIP_VERIFY") != ""
 	enableDebugOutput     = os.Getenv("DEBUG") != ""
 	backendConnectTimeout = getenvDefault("ROUTER_BACKEND_CONNECT_TIMEOUT", "1s")
-	backendHeaderTimeout  = getenvDefault("ROUTER_BACKEND_HEADER_TIMEOUT", "15s")
+	backendHeaderTimeout  = getenvDefault("ROUTER_BACKEND_HEADER_TIMEOUT", "20s")
 )
 
 func usage() {


### PR DESCRIPTION
We're overriding this from 15s to 20s in all environments, so let's just set the default to the value we want and save a bit of noise in configuration files.

See https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/router.pp#L59