### PR TITLE
Update documentation on Go upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,23 @@ This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) to ven
 
 Dependabot raises PR's to update the dependencies for Router. This includes raising a PR when a new version of Go is available. However to update the version of Go, it's necessary to do more than just merge this dependabot PR. Here are the steps:
 
-1. Install the new version of Go on the CI machines. You do this via puppet. See [here](https://github.com/alphagov/govuk-puppet/pull/11457/files) for an example PR. Once this PR has been approved and merged wait for puppet to run, or trigger a puppet run yourself as per [the developer docs](https://docs.publishing.service.gov.uk/manual/deploy-puppet.html#convergence).
+1. Install the new version of Go on the CI machines (See [Why do we install Go on CI machines rather than Cache machines?](#why-do-we-install-go-on-ci-machines-rather-than-cache-machines)). You do this via puppet. See [here](https://github.com/alphagov/govuk-puppet/pull/11457/files) for an example PR. Once this PR has been approved and merged wait for puppet to run, or trigger a puppet run yourself as per [the developer docs](https://docs.publishing.service.gov.uk/manual/deploy-puppet.html#convergence).
 2. Dependabot's PR will modify the Go version in the Dockerfile, but you also need to update the version number in the file `.go-version` See [here](https://github.com/alphagov/router/pull/241/files) for an example PR.
 3. Before you merge this PR, put the branch onto staging and leave it there for a couple of weekdays. Check for anything unexpected in icinga and sentry.
 4. If you are confident that the version bump is safe for production, you can merge your PR and deploy it to production. It is best to do this at a quiet time of the day (such as 7am) to minimise any potential disruption.
+
+#### Why do we install Go on CI machines rather than Cache machines?
+
+Router is built on CI machines; the artefact is then [uploaded to S3](https://github.com/alphagov/router/blob/main/Jenkinsfile#L68) for use in deployment. In  deployment, the artefact is [retrieved from S3](https://github.com/alphagov/govuk-app-deployment/blob/master/router%2Fconfig%2Fdeploy.rb#L30) and uploaded to the cache machines prior to a restart.
+
+The updated version of golang is [only uploaded to Jenkins and CI agents](https://github.com/alphagov/govuk-puppet/search?q=golang).
 
 ### Further documentation
 
 - [Data structure](docs/data-structure.md)
 - [Original thinking behind the router](https://gdstechnology.blog.gov.uk/2013/12/05/building-a-new-router-for-gov-uk)
 - [Example of adding a metric](https://github.com/alphagov/router/commit/b443d3dd9cf776143eed270d01bd98d2233caea6) using the [Go prometheus client library](https://godoc.org/github.com/dnesting/client_golang/prometheus)
+
 
 ## License
 


### PR DESCRIPTION
Adds some useful information from https://github.com/alphagov/govuk-puppet/pull/11579 so that it's not lost
in the sands of time.