### PR TITLE
Ensure GoLang version is correct in CI framework

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.0'
+          go-version: '1.19.2'
           cache: true
 
       - name: Setup MongoDB


### PR DESCRIPTION
GoLang is updated in the Rakefile by Dependabot but it doesn't touch the CI file, which also needs to know the correct version. This is updated here to bring it up to parity with the Rakefile version.

### !!Do Not Merge!!
Until this has been merged and Puppet run: https://github.com/alphagov/govuk-puppet/pull/11859

Related to: https://trello.com/c/lIF8IVxq/1392-bug-investigate-broken-router-builds