### PR TITLE
Remove Jenkins Docker build tasks 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,27 +67,6 @@ node ('mongodb-2.4') {
       }
     }
 
-    if (govuk.hasDockerfile()) {
-      stage("Build Docker image") {
-        govuk.buildDockerImage(repoName, env.BRANCH_NAME)
-      }
-
-      stage("Push Docker image") {
-        govuk.pushDockerImage(repoName, env.BRANCH_NAME)
-      }
-
-      if (env.BRANCH_NAME == "main") {
-        stage("Tag Docker release image") {
-          govuk.pushDockerImage(repoName, env.BRANCH_NAME, "release")
-        }
-
-        stage("Tag Docker release_${env.BUILD_NUMBER} image") {
-          dockerTag = "release_${env.BUILD_NUMBER}"
-          govuk.pushDockerImage(repoName, env.BRANCH_NAME, dockerTag)
-        }
-      }
-    }
-
     if (env.BRANCH_NAME == "main") {
       stage("Push release tag") {
         govuk.pushTag('router', env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, 'main')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ node ('mongodb-2.4') {
       }
 
       stage("Deploy to integration") {
-        govuk.deployIntegration('router', env.BRANCH_NAME, "release_${env.BUILD_NUMBER}", 'deploy')
+        govuk.deployToIntegration('router', "release_${env.BUILD_NUMBER}", 'deploy')
       }
     }
   } catch (e) {


### PR DESCRIPTION
Trello: https://trello.com/c/amnaU0V9/853-decommission-the-publishing-end-to-end-tests

The images produced by this were only used by the publishing-e2e-tests
suite, now that this has been retired [1] we no longer need these
actions and intend to remove them from govuk-jenkinslib.

[1]: https://github.com/alphagov/govuk-jenkinslib/pull/120

This also replaces a deprecated function.