### PR TITLE
Improve container image build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .git
 .gitignore
+Dockerfile
+Jenkinsfile
 README.md
+docs
+integration_tests


### PR DESCRIPTION
Improvements to reduce attack surface, image size, build time/resources and readability of the Dockerfile.

- Speed up the build by using `golang:alpine` as the builder image.
- Add some directories to `.dockerignore` to avoid unnecessary copying during build.
- Include only the Go binary in the output image. For casual troubleshooting we can shell into the `nginx` container and for anything fancy we'd use a rescue container anyway (such as [`kubespy`](https://github.com/huazhihao/kubespy) or similar).
- Strip debug info from the Go binary. This does not break stacktraces.
- Specify `-trimpath` so we don't include the building user's filesystem paths (e.g. `/home/sengi/src/alphagov/router/...`) in the Go binary.
- Respect `TARGETARCH` and `TARGETOS` for cross-compilation.
- Run as an unprivileged user by default.
- Use `ADD` instead of `wget`.
- Remove some duplicate defaults for environment variables. These belong in the app code and shouldn't be overridden in the image build without good reason.
- Remove `GOVUK_APP_NAME`, which is unused.
- Add OCI labels for source and licence.

Build time (--no-cache) on my M1 Max went from 13.5 s to 6.7 s. Output image went from 22.2 MiB to 11.1 MiB (not that the difference in image size matters except for saving a bit of space in the registry).

Tested: works in the integration cluster. Also verified that I can still shell into the `app` container of a Router pod using `kubectl spy`.