### PR TITLE
WIP: Record triemux lookup duration metrics

### DIFF
--- a/triemux/metrics.go
+++ b/triemux/metrics.go
@@ -19,9 +19,26 @@ var (
 		},
 		[]string{"temporary_child"},
 	)
+
+	TrieMuxLookupCountMetric = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "router_triemux_lookup_count",
+			Help: "Number of triemux lookups",
+		},
+	)
+
+	TrieMuxLookupDurationMicrosecondsMetric = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "router_triemux_lookup_duration_microseconds",
+			Help: "Histogram of triemux lookup durations in microseconds",
+		},
+		[]string{},
+	)
 )
 
 func initMetrics() {
 	prometheus.MustRegister(EntryNotFoundCountMetric)
 	prometheus.MustRegister(InternalServiceUnavailableCountMetric)
+	prometheus.MustRegister(TrieMuxLookupCountMetric)
+	prometheus.MustRegister(TrieMuxLookupDurationMicrosecondsMetric)
 }

--- a/triemux/mux.go
+++ b/triemux/mux.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/alphagov/router/logger"
 	"github.com/alphagov/router/trie"
@@ -66,6 +67,16 @@ func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // lookup takes a path and looks up its registered entry in the mux trie,
 // returning the handler for that path, if any matches.
 func (mux *Mux) lookup(path string) (handler http.Handler, ok bool) {
+	startTime := time.Now()
+	defer func() {
+		TrieMuxLookupCountMetric.Inc()
+		TrieMuxLookupDurationMicrosecondsMetric.With(
+			prometheus.Labels{},
+		).Observe(
+			float64(time.Since(startTime).Microseconds()),
+		)
+	}()
+
 	mux.mu.RLock()
 	defer mux.mu.RUnlock()
 

--- a/triemux/mux_test.go
+++ b/triemux/mux_test.go
@@ -167,33 +167,46 @@ var lookupExamples = []LookupExample{
 }
 
 func TestLookup(t *testing.T) {
-	beforeCount := promtest.ToFloat64(EntryNotFoundCountMetric)
+	beforeEntryNotFoundCount := promtest.ToFloat64(EntryNotFoundCountMetric)
+	beforeTrieMuxLookupCount := promtest.ToFloat64(TrieMuxLookupCountMetric)
 
 	for _, ex := range lookupExamples {
 		testLookup(t, ex)
 	}
 
-	afterCount := promtest.ToFloat64(EntryNotFoundCountMetric)
-	notFoundCount := afterCount - beforeCount
+	afterEntryNotFoundCount := promtest.ToFloat64(EntryNotFoundCountMetric)
+	entryNotFoundCount := afterEntryNotFoundCount - beforeEntryNotFoundCount
 
-	var expectedNotFoundCount int
+	afterTrieMuxLookupCount := promtest.ToFloat64(TrieMuxLookupCountMetric)
+	trieMuxLookupCount := afterTrieMuxLookupCount - beforeTrieMuxLookupCount
+
+	var expectedEntryNotFoundCount int
+	var expectedTrieMuxLookupCount int
 
 	for _, ex := range lookupExamples {
 		for _, c := range ex.checks {
+			expectedTrieMuxLookupCount++
 			if !c.ok {
-				expectedNotFoundCount++
+				expectedEntryNotFoundCount++
 			}
 		}
 	}
 
-	if expectedNotFoundCount == 0 {
-		t.Errorf("expectedNotFoundCount should not be zero")
+	if expectedEntryNotFoundCount == 0 {
+		t.Errorf("expectedEntryNotFoundCount should not be zero")
 	}
 
-	if notFoundCount != float64(expectedNotFoundCount) {
+	if entryNotFoundCount != float64(expectedEntryNotFoundCount) {
 		t.Errorf(
-			"Expected notFoundCount (%f) ok to be %f",
-			notFoundCount, float64(expectedNotFoundCount),
+			"Expected entryNotFoundCount (%f) ok to be %f",
+			entryNotFoundCount, float64(expectedEntryNotFoundCount),
+		)
+	}
+
+	if trieMuxLookupCount != float64(expectedTrieMuxLookupCount) {
+		t.Errorf(
+			"Expected trieMuxLookupCount (%f) to be %f",
+			trieMuxLookupCount, float64(expectedTrieMuxLookupCount),
 		)
 	}
 }


### PR DESCRIPTION
WIP because this commit doesn't adequately unit test that the Histogram metric is used.

I think this data would be interesting to look at when talking about alternative options to the triemux approach.

My hypothesis is that the trie based lookups are extremely fast (low number of microseconds), since they're operating in memory over a more or less optimal data structure for the use case.

However, the time taken in the backend handlers is relatively slow (hundreds of milliseconds), so it might not be wise for us to be chasing after every microsecond.

The current trie based approach does have some significant drawbacks in terms of complexity of router:
- we have to load the entire database into memory
- we have to poll the database for changes
- we have to hot-reload the in memory copy of the database without dropping requests

Perhaps it would be worth switching to a more conventional database lookup (i.e. a network call and a B-Tree index scan). This would probably be orders of magnitude slower than the trie based lookup (largely because of the network call), but could still be negligible compared to the time taken in the backend handlers.

Having metrics would help us put concrete numbers on some of these things.