### PR TITLE
Remove test job name to avoid conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   test:
-    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Our govuk-sass-config checks for a test job[1] but we had one named Test. Github check will never pass, so removing this line will mean the job name will revert to the old value of test.

[1]:
https://github.com/alphagov/govuk-saas-config/blob/8cfb23db6a200214411fc1de150d3c8582950588/github/lib/configure_repo.rb#L106