### PR TITLE
Include CA certs in the image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN CGO_ENABLED=0 GOARCH=$TARGETARCH GOOS=$TARGETOS go build -trimpath -ldflags=
 
 FROM scratch
 COPY --from=builder /src/router /bin/router
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=builder /etc/ssl /etc/ssl
 ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem \
     /etc/ssl/certs/rds-combined-ca-bundle.pem
 USER 1001


### PR DESCRIPTION
Router needs this for the TLS connection to the Licensify backend.