### PR TITLE
Rename test to be more descriptive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-go:
+    name: Test Go
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Previously it was simply named "test" which wasn't ideal for moving to EKS. This renaming allows us to properly reference it in the github actions setup over in govuk-saas-config.