### PR TITLE
Stop logging varnish_id.

### DIFF
--- a/integration_tests/error_handling_test.go
+++ b/integration_tests/error_handling_test.go
@@ -43,7 +43,6 @@ var _ = Describe("error handling", func() {
 				"request":        "GET /boom HTTP/1.1",
 				"request_method": "GET",
 				"status":         float64(500), // All numbers in JSON are floating point
-				"varnish_id":     "",
 			}))
 			Expect(logDetails.Timestamp).To(BeTemporally("~", time.Now(), time.Second))
 		})

--- a/integration_tests/proxy_function_test.go
+++ b/integration_tests/proxy_function_test.go
@@ -25,7 +25,6 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 			req, err := http.NewRequest(http.MethodGet, routerURL(routerPort, "/not-running"), nil)
 			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("X-Varnish", "12345678")
 
 			resp := doRequest(req)
 			Expect(resp.StatusCode).To(Equal(502))
@@ -37,7 +36,6 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 				"request_method": "GET",
 				"status":         float64(502), // All numbers in JSON are floating point
 				"upstream_addr":  "127.0.0.1:3164",
-				"varnish_id":     "12345678",
 			}))
 			Expect(logDetails.Timestamp).To(BeTemporally("~", time.Now(), time.Second))
 		})
@@ -53,7 +51,6 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 			req, err := http.NewRequest(http.MethodGet, routerURL(3167, "/should-time-out"), nil)
 			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("X-Varnish", "12345678")
 
 			start := time.Now()
 			resp := doRequest(req)
@@ -69,7 +66,6 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 				"request_method": "GET",
 				"status":         float64(504), // All numbers in JSON are floating point
 				"upstream_addr":  "240.0.0.0:1234",
-				"varnish_id":     "12345678",
 			}))
 			Expect(logDetails.Timestamp).To(BeTemporally("~", time.Now(), time.Second))
 		})
@@ -97,7 +93,6 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 			It("should log and return a 504 if a backend takes longer than the configured response timeout to start returning a response", func() {
 				req := newRequest(http.MethodGet, routerURL(3167, "/tarpit1"))
-				req.Header.Set("X-Varnish", "12341112")
 				resp := doRequest(req)
 				Expect(resp.StatusCode).To(Equal(504))
 
@@ -109,7 +104,6 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 					"request_method": "GET",
 					"status":         float64(504), // All numbers in JSON are floating point
 					"upstream_addr":  tarpitURL.Host,
-					"varnish_id":     "12341112",
 				}))
 				Expect(logDetails.Timestamp).To(BeTemporally("~", time.Now(), time.Second))
 			})

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -90,7 +90,6 @@ func (l *jsonLogger) Log(fields map[string]interface{}) {
 func (l *jsonLogger) LogFromClientRequest(fields map[string]interface{}, req *http.Request) {
 	fields["request_method"] = req.Method
 	fields["request"] = fmt.Sprintf("%s %s %s", req.Method, req.RequestURI, req.Proto)
-	fields["varnish_id"] = req.Header.Get("X-Varnish")
 
 	l.Log(fields)
 }


### PR DESCRIPTION
I can't find any evidence of this ever having been used, and it gives incorrect results because it throws away all but one of the [X-Varnish headers](https://developer.fastly.com/reference/http/http-headers/X-Varnish/). Any request that's reached Router would have [at least two of them](https://developer.fastly.com/learning/vcl/using/#the-vcl-request-lifecycle).

It probably made sense back when we ran our own Varnish and before we had Fastly, when these IDs would have corresponded to request log lines in Varnish.