### PR TITLE
More test improvements.

### DIFF
--- a/integration_tests/metrics_test.go
+++ b/integration_tests/metrics_test.go
@@ -5,16 +5,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("metrics API endpoint", func() {
-	It("should return HTTP OK when receiving a request for /metrics", func() {
-		resp := doRequest(newRequest("GET", routerAPIURL("/metrics")))
-		Expect(resp.StatusCode).To(Equal(200))
-	})
-
-	Context("when looking at metrics returned in response", func() {
-		var (
-			responseBody string
-		)
+var _ = Describe("/metrics API endpoint", func() {
+	Context("response body", func() {
+		var responseBody string
 
 		BeforeEach(func() {
 			resp := doRequest(newRequest("GET", routerAPIURL("/metrics")))
@@ -22,16 +15,8 @@ var _ = Describe("metrics API endpoint", func() {
 			responseBody = readBody(resp)
 		})
 
-		It("should contain router internal server error metrics", func() {
-			Skip("Metric is a vector so it is not registered by default")
-			Expect(responseBody).To(ContainSubstring("router_internal_server_error_total"))
-		})
-
-		It("should contain routing table metrics", func() {
-			Expect(responseBody).To(ContainSubstring("router_route_reload_total"))
-			Expect(responseBody).To(ContainSubstring("router_route_reload_error_total"))
-
-			Expect(responseBody).To(ContainSubstring("router_routes_loaded"))
+		It("should contain at least one metric", func() {
+			Expect(responseBody).To(ContainSubstring("router_"))
 		})
 	})
 })

--- a/integration_tests/performance_test.go
+++ b/integration_tests/performance_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"net/http/httptest"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -85,42 +84,34 @@ var _ = Describe("Performance", func() {
 			})
 		})
 
-		if os.Getenv("RUN_ULIMIT_DEPENDENT_TESTS") != "" {
-			Describe("high request throughput", func() {
-				It("should not significantly increase latency", func() {
-					assertPerformantRouter(backend1, backend2, 3000)
-				})
+		Describe("high request throughput", func() {
+			It("should not significantly increase latency", func() {
+				assertPerformantRouter(backend1, backend2, 3000)
 			})
-		}
+		})
 	})
 
-	Describe("many concurrent (slow) connections", func() {
-		if os.Getenv("RUN_ULIMIT_DEPENDENT_TESTS") != "" {
-			var (
-				backend1 *httptest.Server
-				backend2 *httptest.Server
-			)
+	Describe("many concurrent slow connections", func() {
+		var backend1 *httptest.Server
+		var backend2 *httptest.Server
 
-			BeforeEach(func() {
-				backend1 = startTarpitBackend(time.Second)
-				backend2 = startTarpitBackend(time.Second)
-				addBackend("backend-1", backend1.URL)
-				addBackend("backend-2", backend2.URL)
-				addRoute("/one", NewBackendRoute("backend-1"))
-				addRoute("/two", NewBackendRoute("backend-2"))
-				reloadRoutes()
-			})
-			AfterEach(func() {
-				backend1.Close()
-				backend2.Close()
-			})
+		BeforeEach(func() {
+			backend1 = startTarpitBackend(time.Second)
+			backend2 = startTarpitBackend(time.Second)
+			addBackend("backend-1", backend1.URL)
+			addBackend("backend-2", backend2.URL)
+			addRoute("/one", NewBackendRoute("backend-1"))
+			addRoute("/two", NewBackendRoute("backend-2"))
+			reloadRoutes()
+		})
+		AfterEach(func() {
+			backend1.Close()
+			backend2.Close()
+		})
 
-			It("should not significantly increase latency", func() {
-				assertPerformantRouter(backend1, backend2, 1000)
-			})
-		} else {
-			PIt("high throughput requires elevated ulimit")
-		}
+		It("should not significantly increase latency", func() {
+			assertPerformantRouter(backend1, backend2, 1000)
+		})
 	})
 })
 

--- a/metrics.go
+++ b/metrics.go
@@ -16,14 +16,14 @@ var (
 	routeReloadCountMetric = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "router_route_reload_total",
-			Help: "Number of times routing table has been reloaded",
+			Help: "Total number of attempts to reload the routing table",
 		},
 	)
 
 	routeReloadErrorCountMetric = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "router_route_reload_error_total",
-			Help: "Number of errors encountered by reloading routing table",
+			Help: "Number of failed attempts to reload the routing table",
 		},
 	)
 


### PR DESCRIPTION
- Delete some cruft from the metrics integration tests. All it was really doing was looking for a plausible 200 OK response for `/metrics`, so make it explicitly just do that and don't pretend to test the actual metrics. We should add proper unit tests (not integration tests) to check that counters are incremented when they're supposed to be (see [prometheus/testutil](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus/testutil)).
- Refactor the performance tests and make them generate a realistic request rate (50 qps for most tests and 500 qps for the high-throughput ones, instead of 1.7 qps and 50 qps respectively).