### PR TITLE
Lightly clean up Sentry event logging.

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/alphagov/router/handlers"
 	router "github.com/alphagov/router/lib"
+	"github.com/alphagov/router/logger"
+	sentry "github.com/getsentry/sentry-go"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -130,6 +132,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	logger.InitSentry()
+	defer sentry.Flush(2 * time.Second)
+
 	log.Printf("router: listening for API requests on %v", apiAddr)
 	listenAndServeOrFatal(apiAddr, api, feReadTimeout, feWriteTimeout)
 }


### PR DESCRIPTION
We're still quite some way from using the Sentry API as intended, but this at least makes our usage a bit less weird/buggy and more readable.

- Send events to Sentry asynchronously, instead of blocking.
- Allow up to 2 s to finish sending events to Sentry on exit.
- Manage the lifecycle of the sentry.Client, Hub and Scope objects the way we're supposed to, rather than reinitialising Sentry every time we send an event.
- Remove the unexported methods on our (still somewhat sketchy) ReportableError type; these weren't helping readability.

Relevant docs:

- https://docs.sentry.io/platforms/go/usage/
- https://docs.sentry.io/platforms/go/enriching-events/scopes/
- https://docs.sentry.io/platforms/go/concurrency/
- https://docs.sentry.io/platforms/go/panics/
- https://docs.sentry.io/platforms/go/guides/http/
- https://github.com/getsentry/sentry-go/blob/master/_examples/http/main.go