### PR TITLE
Simplify the route data structures.

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,5 +1,6 @@
-The MIT License (MIT)
-Copyright (c) 2013 Government Digital Service
+MIT Licence
+
+Copyright © 2013-2023 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/trie/LICENSE
+++ b/trie/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2013 Government Digital Service
+MIT Licence
+
+Copyright © 2013, 2023 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/trie/README.md
+++ b/trie/README.md
@@ -7,8 +7,8 @@ rather than just strings.
 This makes it suitable for efficiently storing information about hierarchical
 systems in general, rather than being specifically geared towards string lookup.
 
-Read the documentation on [godoc.org][docs] for details of how to use `trie`.
+See also the [Godoc documentation for
+`trie`](https://pkg.go.dev/github.com/alphagov/router/trie).
 
-[docs]: http://godoc.org/github.com/alphagov/router/trie
-[go]: http://golang.org
+[go]: https://go.dev/
 [trie]: https://en.wikipedia.org/wiki/Trie

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -4,52 +4,54 @@ import (
 	"testing"
 )
 
-type Meth int
+type method int
 
 const (
-	Set Meth = iota
+	Set method = iota
 	Del
 )
 
-type Pair struct {
-	meth Meth
-	path []string
-	val  interface{}
+type FixtureRow struct {
+	method method
+	path   []string
+	val    interface{}
 }
 
-type Check struct {
+type Expectation struct {
 	path []string
 	val  interface{}
 	ok   bool
 }
 
 type Example struct {
-	pairs  []Pair
-	checks []Check
+	fixtures     []FixtureRow
+	expectations []Expectation
 }
 
-// Data driven testing. Each Example consists of a slice of Pairs which are
-// "set" in the Trie, and a set of Checks, which consist of a Trie path and
-// expected return values and "ok" checks.
+// In these table-driven tests, each Example consists of:
+// 
+//   - a slice of FixtureRows which are inserted into the Trie
+//   - a set of Expectations, which consist of a Trie path and expected return
+//     values and "ok" checks
 //
-// TestExamples iterates through the examples slice and runs all the Checks
-// having set up a Trie with the appropriate Pairs.
+// TestExamples iterates over each test case in `examples`, setting up the
+// fixture and asserting the corresponding Expectations.
 var examples = []Example{
 	{ // Simple setting and getting
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo"}, "bar"},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo"}, "bar", true},
 			{[]string{"baz"}, nil, false},
 			{[]string{"foo", "bar"}, nil, false},
 		},
 	},
 	{ // Multiple path components
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo", "bar"}, 123},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo", "bar"}, 123, true},
 			{[]string{"baz"}, nil, false},
 			{[]string{"foo", "baz"}, nil, false},
@@ -58,11 +60,11 @@ var examples = []Example{
 		},
 	},
 	{ // Multiple values on the same path
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo"}, "hello"},
 			{Set, []string{"foo", "bar"}, 123},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo", "bar"}, 123, true},
 			{[]string{"foo"}, "hello", true},
 			{[]string{"foo", "baz"}, nil, false},
@@ -71,27 +73,27 @@ var examples = []Example{
 		},
 	},
 	{ // Deleting
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo"}, "hello"},
 			{Del, []string{"foo"}, nil},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo"}, nil, false},
 		},
 	},
 	{ // Setting at the root
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{}, "hello"},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{}, "hello", true},
 		},
 	},
 	{ // Setting nil
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo"}, nil},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo"}, nil, true},
 		},
 	},
@@ -99,11 +101,11 @@ var examples = []Example{
 
 var prefixExamples = []Example{
 	{ // Multiple values on the same path
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo"}, "hello"},
 			{Set, []string{"foo", "bar"}, 123},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo", "bar"}, 123, true},
 			{[]string{"foo"}, "hello", true},
 			{[]string{"foo", "baz"}, "hello", true},
@@ -113,11 +115,11 @@ var prefixExamples = []Example{
 		},
 	},
 	{ // Multiple values on the same path with gaps
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo"}, "hello"},
 			{Set, []string{"foo", "bar", "baz"}, 123},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo", "bar", "baz"}, 123, true},
 			{[]string{"foo"}, "hello", true},
 			{[]string{"foo", "baz"}, "hello", true},
@@ -127,12 +129,12 @@ var prefixExamples = []Example{
 		},
 	},
 	{ // Deleting
-		[]Pair{
+		[]FixtureRow{
 			{Set, []string{"foo"}, "hello"},
 			{Set, []string{"foo", "bar", "baz"}, 123},
 			{Del, []string{"foo", "bar", "baz"}, nil},
 		},
-		[]Check{
+		[]Expectation{
 			{[]string{"foo", "bar", "baz"}, "hello", true},
 		},
 	},
@@ -140,7 +142,7 @@ var prefixExamples = []Example{
 
 func TestNew(t *testing.T) {
 	path := []string{"hello", "world"}
-	trie := NewTrie()
+	trie := NewTrie[interface{}]()
 	_, ok := trie.Get(path)
 	if ok {
 		t.Error("An empty Trie should not contain any entries")
@@ -154,15 +156,15 @@ func TestExamples(t *testing.T) {
 }
 
 func testExample(t *testing.T, i int, ex Example) {
-	trie := buildExampleTrie(t, ex.pairs)
-	for _, c := range ex.checks {
-		val, ok := trie.Get(c.path)
-		t.Logf("trie.Get(path:%v) -> val:%v, ok:%v", c.path, val, ok)
-		if ok != c.ok {
-			t.Errorf("Example %d check %+v: trie.Get ok was %v (expected %v)", i, c, ok, c.ok)
+	trie := buildExampleTrie(t, ex.fixtures)
+	for _, e := range ex.expectations {
+		val, ok := trie.Get(e.path)
+		t.Logf("trie.Get(path:%v) -> val:%v, ok:%v", e.path, val, ok)
+		if ok != e.ok {
+			t.Errorf("Example %d check %+v: trie.Get ok was %v (expected %v)", i, e, ok, e.ok)
 		}
-		if val != c.val {
-			t.Errorf("Example %d check %+v: trie.Get val was %v (expected %v)", i, c, val, c.val)
+		if val != e.val {
+			t.Errorf("Example %d check %+v: trie.Get val was %v (expected %v)", i, e, val, e.val)
 		}
 	}
 }
@@ -174,45 +176,45 @@ func TestPrefixExamples(t *testing.T) {
 }
 
 func testPrefixExample(t *testing.T, i int, ex Example) {
-	trie := buildExampleTrie(t, ex.pairs)
-	for _, c := range ex.checks {
-		val, ok := trie.GetLongestPrefix(c.path)
-		t.Logf("trie.GetLongestPrefix(path:%v) -> val:%v, ok:%v", c.path, val, ok)
-		if ok != c.ok {
-			t.Errorf("Example %d check %+v: trie.Get ok was %v (expected %v)", i, c, ok, c.ok)
+	trie := buildExampleTrie(t, ex.fixtures)
+	for _, e := range ex.expectations {
+		val, ok := trie.GetLongestPrefix(e.path)
+		t.Logf("trie.GetLongestPrefix(path:%v) -> val:%v, ok:%v", e.path, val, ok)
+		if ok != e.ok {
+			t.Errorf("Example %d check %+v: trie.Get ok was %v (expected %v)", i, e, ok, e.ok)
 		}
-		if val != c.val {
-			t.Errorf("Example %d check %+v: trie.Get val was %v (expected %v)", i, c, val, c.val)
+		if val != e.val {
+			t.Errorf("Example %d check %+v: trie.Get val was %v (expected %v)", i, e, val, e.val)
 		}
 	}
 }
 
 func TestDelReturnsStatus(t *testing.T) {
-	trie := NewTrie()
+	trie := NewTrie[interface{}]()
 	path := []string{"foo"}
 	trie.Set(path, "bar")
 	ok := trie.Del(path)
 	if !ok {
-		t.Error("trie.Del didn't return true when deleting a key that exists!")
+		t.Error("trie.Del didn't return true when deleting a key that exists")
 	}
 	ok = trie.Del(path)
 	if ok {
-		t.Error("trie.Del didn't return false when deleting a key that didn't exist!")
+		t.Error("trie.Del didn't return false when deleting a key that didn't exist")
 	}
 }
 
-func buildExampleTrie(t *testing.T, pairs []Pair) *Trie {
-	trie := NewTrie()
-	for _, p := range pairs {
-		switch p.meth {
+func buildExampleTrie(t *testing.T, fixtures []FixtureRow) *Trie[interface{}] {
+	trie := NewTrie[interface{}]()
+	for _, f := range fixtures {
+		switch f.method {
 		case Set:
-			trie.Set(p.path, p.val)
-			t.Logf("trie.Set(path:%v, val:%v)", p.path, p.val)
+			trie.Set(f.path, f.val)
+			t.Logf("trie.Set(path:%v, val:%v)", f.path, f.val)
 		case Del:
-			trie.Del(p.path)
-			t.Logf("trie.Del(path:%v)", p.path)
+			trie.Del(f.path)
+			t.Logf("trie.Del(path:%v)", f.path)
 		default:
-			t.Errorf("Unrecognised method %v in Pair %v", p.meth, p)
+			t.Errorf("Unrecognised method %v in FixtureRow %v", f.method, f)
 		}
 	}
 	return trie

--- a/triemux/LICENSE
+++ b/triemux/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2013 Government Digital Service
+MIT Licence
+
+Copyright © 2013, 2023 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/triemux/mux_test.go
+++ b/triemux/mux_test.go
@@ -29,20 +29,20 @@ var splitExamples = []SplitExample{
 	{"/foo/////bar/", []string{"foo", "bar"}},
 }
 
-func TestSplitpath(t *testing.T) {
+func TestSplitPath(t *testing.T) {
 	for _, ex := range splitExamples {
-		testSplitpath(t, ex)
+		testSplitPath(t, ex)
 	}
 }
 
-func testSplitpath(t *testing.T, ex SplitExample) {
-	out := splitpath(ex.in)
+func testSplitPath(t *testing.T, ex SplitExample) {
+	out := splitPath(ex.in)
 	if len(out) != len(ex.out) {
-		t.Errorf("splitpath(%v) was not %v", ex.in, ex.out)
+		t.Errorf("splitPath(%v) was not %v", ex.in, ex.out)
 	}
 	for i := range ex.out {
 		if out[i] != ex.out[i] {
-			t.Errorf("splitpath(%v) differed from %v at component %d "+
+			t.Errorf("splitPath(%v) differed from %v at component %d "+
 				"(expected %v, got %v)", out, ex.out, i, ex.out[i], out[i])
 		}
 	}


### PR DESCRIPTION
- Use generics (introduced in Go 1.18) to ensure type safety at compile time instead of using type introspection (type assertions) at runtime.
- Drop the unused `prefix` flag in the trie node objects; just point directly to the http.Handler (interface). Improves readability and saves an unnecessary indirection on every lookup.
- Make the clever table-driven unit tests a bit more readable by using more common terminology.
- Unexport some symbols which shouldn't have been exported (and thankfully hadn't been used externally, at least not in any public repos anyway).
- Minor editorial improvements to documentation.
- Update the copyright assertions to keep them accurate.