### PR TITLE
Remove an esoteric example from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,6 @@ To see debug messages when running tests, set both the `ROUTER_DEBUG` and
 `ROUTER_DEBUG_TESTS` environment variables:
 
 ```sh
-export ROUTER_DEBUG=1 ROUTER_DEBUG_TESTS=1
-```
-
-or equivalently for a single run:
-
-```sh
 ROUTER_DEBUG=1 ROUTER_DEBUG_TESTS=1 make test
 ```
 


### PR DESCRIPTION
One example of running the tests with debug logging suffices. Keep the more portable of the two.

Slightly improves the signal/noise ratio, especially since this is the top-level README.