### PR TITLE
Update README to reflect change of maintainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ loads a routing table into memory from a MongoDB database and:
 The sister project [`router-api`][router-api] provides a read/write
 interface to the underlying database.
 
-[tm]: https://github.com/alphagov/router/tree/master/triemux
+[tm]: https://github.com/alphagov/router/tree/main/triemux
 [router-api]: https://github.com/alphagov/router-api
 
 ## Technical documentation
@@ -101,8 +101,8 @@ This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) to ven
 ### Further documentation
 
 - [Data structure](docs/data-structure.md)
-- [Original thinking behind the router](https://gdstechnology.blog.gov.uk/2013/12/05/building-a-new-router-for-gov-uk)
-- [Example of adding a metric](https://github.com/alphagov/router/commit/b443d3d) using the [Go prometheus client library](https://godoc.org/github.com/dnesting/client_golang/prometheus)
+- [Original thinking behind the router](https://technology.blog.gov.uk/2013/12/05/building-a-new-router-for-gov-uk/)
+- [Example of adding a metric](https://github.com/alphagov/router/commit/b443d3d) using the [Go prometheus client library](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus)
 
 ## Team
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ loads a routing table into memory from a MongoDB database and:
 The sister project [`router-api`][router-api] provides a read/write
 interface to the underlying database.
 
-[tm]: https://github.com/alphagov/router/tree/main/triemux
-[router-api]: https://github.com/alphagov/router-api
-
 ## Technical documentation
 
 Recommended reading: [How to Write Go Code](https://golang.org/doc/code.html)
@@ -70,15 +67,15 @@ This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) to ven
 
 1. Update all the dependencies, including test dependencies, in your working copy:
 
-    ```sh
-    make update_deps
-    ```
+   ```sh
+   make update_deps
+   ```
 
 1. Check for any errors and commit.
 
-    ```sh
-    git commit -- go.{mod,sum} vendor
-    ```
+   ```sh
+   git commit -- go.{mod,sum} vendor
+   ```
 
 1. [Run the Router test suite](#run-the-test-suite). If you need to fix a
    failing test, keep your changes in separate commits to the `go get` /
@@ -86,15 +83,15 @@ This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) to ven
 
 1. Run the tests for all dependencies:
 
-    ```sh
-    go test all
-    ```
+   ```sh
+   go test all
+   ```
 
-    - If there are failures, look into each one and determine whether it needs
-      fixing.
-    - If anything under `vendor/` needs changing then either raise a PR with
-      the upstream project or revert to a set of versions that work together.
-      Only `go get` and `go mod` should touch files in `vendor/`.
+   - If there are failures, look into each one and determine whether it needs
+     fixing.
+   - If anything under `vendor/` needs changing then either raise a PR with
+     the upstream project or revert to a set of versions that work together.
+     Only `go get` and `go mod` should touch files in `vendor/`.
 
 1. Raise a PR.
 
@@ -117,3 +114,5 @@ board](https://trello.com/b/u4FCzm53/).
 [MIT License](LICENCE)
 
 [#govuk-platform-engineering]: https://gds.slack.com/channels/govuk-platform-engineering
+[router-api]: https://github.com/alphagov/router-api
+[tm]: https://github.com/alphagov/router/tree/main/triemux

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) to ven
 - [Original thinking behind the router](https://gdstechnology.blog.gov.uk/2013/12/05/building-a-new-router-for-gov-uk)
 - [Example of adding a metric](https://github.com/alphagov/router/commit/b443d3d) using the [Go prometheus client library](https://godoc.org/github.com/dnesting/client_golang/prometheus)
 
+## Team
+
+[GOV.UK Platform
+Engineering](https://github.com/orgs/alphagov/teams/gov-uk-platform-engineering)
+team looks after this repo. If you're inside GDS, you can find us in
+[#govuk-platform-engineering] or view our [kanban
+board](https://trello.com/b/u4FCzm53/).
+
 ## Licence
 
 [MIT License](LICENCE)
+
+[#govuk-platform-engineering]: https://gds.slack.com/channels/govuk-platform-engineering

--- a/trie/README.md
+++ b/trie/README.md
@@ -1,7 +1,6 @@
-trie
-----
+## trie
 
-A minimal implementation of a [trie data structure][trie] for [Go][go]. Differs
+A minimal implementation of a [trie data structure][trie] for [Go]. Differs
 from most implementations in that it uses string slices (`[]string`) as keys,
 rather than just strings.
 
@@ -10,6 +9,6 @@ systems in general, rather than being specifically geared towards string lookup.
 
 Read the documentation on [godoc.org][docs] for details of how to use `trie`.
 
-[trie]: https://en.wikipedia.org/wiki/Trie
-[go]: http://golang.org
 [docs]: http://godoc.org/github.com/alphagov/router/trie
+[go]: http://golang.org
+[trie]: https://en.wikipedia.org/wiki/Trie

--- a/triemux/README.md
+++ b/triemux/README.md
@@ -1,5 +1,4 @@
-triemux
-=======
+# triemux
 
 `triemux` is an implementation of [Go]'s [`http.Handler`][handler] that
 multiplexes a set of other handlers onto a single path hierarchy, using an
@@ -9,41 +8,42 @@ domain to be served by different applications.
 
 API documentation for `triemux` can be found at [godoc.org][docs].
 
-[handler]: https://pkg.go.dev/net/http#Handler
-[Go]: https://go.dev/
-[docs]: https://pkg.go.dev/github.com/alphagov/router/triemux
+## Install
 
-Install
--------
+```
+go install github.com/alphagov/router/triemux
+```
 
-    go install github.com/alphagov/router/triemux
+## Usage
 
-Usage
------
+```
+mux := triemux.NewMux()
 
-    mux := triemux.NewMux()
+com := httputil.NewSingleHostReverseProxy(url.Parse("https://example.com"))
+org := httputil.NewSingleHostReverseProxy(url.Parse("https://example.org"))
 
-    com := httputil.NewSingleHostReverseProxy(url.Parse("https://example.com"))
-    org := httputil.NewSingleHostReverseProxy(url.Parse("https://example.org"))
+// Register a prefix route pointing to the "com" backend (all requests to
+// "/com<anything>" will go to this backend).
+mux.Handle("/com", true, com)
 
-    // Register a prefix route pointing to the "com" backend (all requests to
-    // "/com<anything>" will go to this backend).
-    mux.Handle("/com", true, com)
+// Register an exact (non-prefix) route pointing to the "org" backend.
+mux.Handle("/org", false, org)
 
-    // Register an exact (non-prefix) route pointing to the "org" backend.
-    mux.Handle("/org", false, org)
+...
 
-    ...
+srv := &http.Server{
+        Addr:         ":8080",
+        Handler:      mux,
+        ReadTimeout:  60 * time.Second(),
+        WriteTimeout: 60 * time.Second(),
+}
+srv.ListenAndServe()
+```
 
-    srv := &http.Server{
-            Addr:         ":8080",
-            Handler:      mux,
-            ReadTimeout:  60 * time.Second(),
-            WriteTimeout: 60 * time.Second(),
-    }
-    srv.ListenAndServe()
-
-Licence
--------
+## Licence
 
 `triemux` is released under the MIT licence, a copy of which can be found in `LICENCE`.
+
+[docs]: https://pkg.go.dev/github.com/alphagov/router/triemux
+[go]: https://go.dev/
+[handler]: https://pkg.go.dev/net/http#Handler


### PR DESCRIPTION
Platform Engineering now maintains Router (and [Router API](https://github.com/alphagov/router-api)). Update the top-level README to reflect this and help make it discoverable.

Also update some links and run mdformat while we're updating READMEs.