### PR TITLE
Redirect all-caps article slugs to lowercase.

### DIFF
--- a/handlers/redirect_handler.go
+++ b/handlers/redirect_handler.go
@@ -31,16 +31,16 @@ func NewRedirectHandler(source, target string, preserve bool, temporary bool) ht
 	return &redirectHandler{target, statusMoved}
 }
 
-func addCacheHeaders(writer http.ResponseWriter) {
-	writer.Header().Set("Expires", time.Now().Add(cacheDuration).Format(time.RFC1123))
-	writer.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public", cacheDuration/time.Second))
+func addCacheHeaders(w http.ResponseWriter) {
+	w.Header().Set("Expires", time.Now().Add(cacheDuration).Format(time.RFC1123))
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public", cacheDuration/time.Second))
 }
 
-func addGAQueryParam(target string, request *http.Request) string {
-	if ga := request.URL.Query().Get("_ga"); ga != "" {
+func addGAQueryParam(target string, r *http.Request) string {
+	if ga := r.URL.Query().Get("_ga"); ga != "" {
 		u, err := url.Parse(target)
 		if err != nil {
-			defer logger.NotifySentry(logger.ReportableError{Error: err, Request: request})
+			defer logger.NotifySentry(logger.ReportableError{Error: err, Request: r})
 			return target
 		}
 		values := u.Query()
@@ -56,11 +56,11 @@ type redirectHandler struct {
 	code int
 }
 
-func (handler *redirectHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
-	addCacheHeaders(writer)
+func (handler *redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	addCacheHeaders(w)
 
-	target := addGAQueryParam(handler.url, request)
-	http.Redirect(writer, request, target, handler.code)
+	target := addGAQueryParam(handler.url, r)
+	http.Redirect(w, r, target, handler.code)
 
 	redirectCountMetric.With(prometheus.Labels{
 		"redirect_code": fmt.Sprintf("%d", handler.code),
@@ -74,14 +74,14 @@ type pathPreservingRedirectHandler struct {
 	code         int
 }
 
-func (handler *pathPreservingRedirectHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
-	target := handler.targetPrefix + strings.TrimPrefix(request.URL.Path, handler.sourcePrefix)
-	if request.URL.RawQuery != "" {
-		target += "?" + request.URL.RawQuery
+func (handler *pathPreservingRedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	target := handler.targetPrefix + strings.TrimPrefix(r.URL.Path, handler.sourcePrefix)
+	if r.URL.RawQuery != "" {
+		target += "?" + r.URL.RawQuery
 	}
 
-	addCacheHeaders(writer)
-	http.Redirect(writer, request, target, handler.code)
+	addCacheHeaders(w)
+	http.Redirect(w, r, target, handler.code)
 
 	redirectCountMetric.With(prometheus.Labels{
 		"redirect_code": fmt.Sprintf("%d", handler.code),

--- a/triemux/mux.go
+++ b/triemux/mux.go
@@ -5,9 +5,11 @@ package triemux
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 
+	"github.com/alphagov/router/handlers"
 	"github.com/alphagov/router/logger"
 	"github.com/alphagov/router/trie"
 )
@@ -17,20 +19,22 @@ type Mux struct {
 	exactTrie  *trie.Trie[http.Handler]
 	prefixTrie *trie.Trie[http.Handler]
 	count      int
+	downcaser  http.Handler
 }
 
 // NewMux makes a new empty Mux.
 func NewMux() *Mux {
 	return &Mux{
-		exactTrie: trie.NewTrie[http.Handler](),
+		exactTrie:  trie.NewTrie[http.Handler](),
 		prefixTrie: trie.NewTrie[http.Handler](),
+		downcaser:  handlers.NewDowncaseRedirectHandler(),
 	}
 }
 
-// ServeHTTP dispatches the request to a backend with a registered route
-// matching the request path, or 404s.
-//
-// If the routing table is empty, return a 503.
+// ServeHTTP forwards the request to a backend with a registered route matching
+// the request path. Serves 404 when there is no backend. Serves 301 redirect
+// to lowercase path when the URL path is entirely uppercase. Serves 503 when
+// no routes are loaded.
 func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if mux.count == 0 {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -42,12 +46,28 @@ func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if shouldRedirToLowercasePath(r.URL.Path) {
+		mux.downcaser.ServeHTTP(w, r)
+		return
+	}
+
 	handler, ok := mux.lookup(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
 	handler.ServeHTTP(w, r)
+}
+
+// shouldRedirToLowercasePath takes a URL path string (such as "/government/guidance")
+// and returns:
+//   - true, if path is in all caps; for example:
+//     "/GOVERNMENT/GUIDANCE" -> true (should redirect to "/government/guidance")
+//   - false, otherwise; for example:
+//     "/GoVeRnMeNt/gUiDaNcE" -> false (should forward "/GoVeRnMeNt/gUiDaNcE" as-is)
+func shouldRedirToLowercasePath(path string) (match bool) {
+	match, _ = regexp.MatchString(`^\/[A-Z]+[A-Z\W\d]+$`, path)
+	return
 }
 
 // lookup finds a URL path in the Mux and returns the corresponding handler.

--- a/triemux/mux_test.go
+++ b/triemux/mux_test.go
@@ -10,47 +10,57 @@ import (
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-type SplitExample struct {
-	in  string
-	out []string
-}
-
-var splitExamples = []SplitExample{
-	{"", []string{}},
-	{"/", []string{}},
-	{"foo", []string{"foo"}},
-	{"/foo", []string{"foo"}},
-	{"/füßball", []string{"füßball"}},
-	{"/foo/bar", []string{"foo", "bar"}},
-	{"///foo/bar", []string{"foo", "bar"}},
-	{"foo/bar", []string{"foo", "bar"}},
-	{"/foo/bar/", []string{"foo", "bar"}},
-	{"/foo//bar/", []string{"foo", "bar"}},
-	{"/foo/////bar/", []string{"foo", "bar"}},
-}
-
 func TestSplitPath(t *testing.T) {
-	for _, ex := range splitExamples {
-		testSplitPath(t, ex)
+	tests := []struct {
+		in  string
+		out []string
+	}{
+		{"", []string{}},
+		{"/", []string{}},
+		{"foo", []string{"foo"}},
+		{"/foo", []string{"foo"}},
+		{"/füßball", []string{"füßball"}},
+		{"/foo/bar", []string{"foo", "bar"}},
+		{"///foo/bar", []string{"foo", "bar"}},
+		{"foo/bar", []string{"foo", "bar"}},
+		{"/foo/bar/", []string{"foo", "bar"}},
+		{"/foo//bar/", []string{"foo", "bar"}},
+		{"/foo/////bar/", []string{"foo", "bar"}},
 	}
-}
 
-func testSplitPath(t *testing.T, ex SplitExample) {
-	out := splitPath(ex.in)
-	if len(out) != len(ex.out) {
-		t.Errorf("splitPath(%v) was not %v", ex.in, ex.out)
-	}
-	for i := range ex.out {
-		if out[i] != ex.out[i] {
-			t.Errorf("splitPath(%v) differed from %v at component %d "+
-				"(expected %v, got %v)", out, ex.out, i, ex.out[i], out[i])
+	for _, ex := range tests {
+		out := splitPath(ex.in)
+		if len(out) != len(ex.out) {
+			t.Errorf("splitPath(%v) was not %v", ex.in, ex.out)
+		}
+		for i := range ex.out {
+			if out[i] != ex.out[i] {
+				t.Errorf("splitPath(%v) differed from %v at component %d "+
+					"(expected %v, got %v)", out, ex.out, i, ex.out[i], out[i])
+			}
 		}
 	}
 }
 
-type DummyHandler struct {
-	id string
+func TestShouldRedirToLowercasePath(t *testing.T) {
+	tests := []struct {
+		in  string
+		out bool
+	}{
+		{"/GOVERNMENT/GUIDANCE", true},
+		{"/GoVeRnMeNt/gUiDaNcE", false},
+		{"/government/guidance", false},
+	}
+
+	for _, ex := range tests {
+		out := shouldRedirToLowercasePath(ex.in)
+		if out != ex.out {
+			t.Errorf("shouldRedirToLowercasePath(%v): expected %v, got %v", ex.in, ex.out, out)
+		}
+	}
 }
+
+type DummyHandler struct{ id string }
 
 func (dh *DummyHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {}
 


### PR DESCRIPTION
Move this redirect functionality from nginx into Router, so that we can finally drop Perl from the nginx config.

We'll need to push this further down into the backend ("frontend") apps when we get rid of Router, but there's still value in eliminating Perl from the request path sooner rather than later.

Also some trivial style cleanup in proxy_function integration tests.