### PR TITLE
Move gosec annotation so that it continues to work.

### DIFF
--- a/handlers/backend_handler.go
+++ b/handlers/backend_handler.go
@@ -116,8 +116,8 @@ func newBackendTransport(
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.ExpectContinueTimeout = 1 * time.Second
 
-	// #nosec G402 -- TODO: fix tests to use TLS properly.
 	if TLSSkipVerify {
+		// #nosec G402 -- TODO: fix tests to use TLS properly.
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 


### PR DESCRIPTION
Seems the semantics of gosec's exclusion comments subtly changed recently :/ Moving the comment inside the block / directly above the statement it applies to seems to fix it.