### PR TITLE
Increase timeout for Mongo setup in tests.

### DIFF
--- a/mongo.sh
+++ b/mongo.sh
@@ -31,7 +31,7 @@ healthy() {
 
 # usage: retry_or_fatal description command-to-try
 retry_or_fatal() {
-  n=10
+  n=20
   echo -n "Waiting up to $n s for $1"; shift
   while [ "$n" -ge 0 ]; do
     if "$@"; then


### PR DESCRIPTION
This seems to have become flaky recently (but only on GitHub Actions), so try waiting a bit longer for MongoDB startup.

Might improve #433. If not then we can dig deeper.