### PR TITLE
Toil reduction: use current golangci-lint version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,3 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@82d40c283aeb1f2b6595839195e95c2d6a49081b  # v5.0.0
-        with:
-          version: v1.55.2


### PR DESCRIPTION
The benefits of this being automatically up to date outweigh the (tiny and largely theoretical) drawback of new lints appearing unexpectedly (which we'd likely want to fix anyway).