### PR TITLE
Get multi-arch builds for Router.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG go_registry=""
 ARG go_version=1.22
 ARG go_tag_suffix=-alpine
 
-FROM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder
+FROM --platform=$TARGETPLATFORM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder
 ARG TARGETARCH TARGETOS
 ARG GOARCH=$TARGETARCH GOOS=$TARGETOS
 ARG CGO_ENABLED=0
@@ -18,7 +18,7 @@ RUN go build -ldflags="$go_ldflags" && \
     ./router -version && \
     go version -m ./router
 
-FROM scratch
+FROM --platform=$TARGETPLATFORM scratch
 COPY --from=builder /src/router /bin/router
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 COPY --from=builder /etc/ssl /etc/ssl


### PR DESCRIPTION
## What?
This switches router over to the multi-arch build workflow and adds the `--platform` flag to the Dockerfile.