### PR TITLE
Remove unused RDS CA cert bundles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,6 @@ FROM --platform=$TARGETPLATFORM scratch
 COPY --from=builder /src/router /bin/router
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 COPY --from=builder /etc/ssl /etc/ssl
-# TODO: remove rds-combined-ca-bundle.pem once app is using global-bundle.pem.
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem \
-    /etc/ssl/certs/rds-combined-ca-bundle.pem
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
-    /etc/ssl/certs/rds-global-bundle.pem
 USER 1001
 CMD ["/bin/router"]
 LABEL org.opencontainers.image.source="https://github.com/alphagov/router"


### PR DESCRIPTION
We're not using these and we're unlikely to any time soon. It's also easy to add them back in if we did want them later.