### PR TITLE
Increase the mongo startup timeout for tests

### DIFF
--- a/mongo.sh
+++ b/mongo.sh
@@ -31,7 +31,7 @@ healthy() {
 
 # usage: retry_or_fatal description command-to-try
 retry_or_fatal() {
-  n=20
+  n=60
   echo -n "Waiting up to $n s for $1"; shift
   while [ "$n" -ge 0 ]; do
     if "$@"; then


### PR DESCRIPTION
Tests frequently timeout and fail whilst waiting for MongoDB to startup. This increases the timeout to reduce the flakey-ness of these tests.