### PR TITLE
Add source label for router reload metrics

### DIFF
--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -26,14 +26,15 @@ var (
 				0.99: 0.005,
 			},
 		},
-		[]string{"success"},
+		[]string{"success", "source"},
 	)
 
-	routesCountMetric = prometheus.NewGauge(
+	routesCountMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "router_routes_loaded",
 			Help: "Number of routes currently loaded",
 		},
+		[]string{"source"},
 	)
 )
 

--- a/lib/router.go
+++ b/lib/router.go
@@ -214,7 +214,7 @@ type mongoDatabase interface {
 func (rt *Router) reloadRoutes(db *mgo.Database, currentOptime bson.MongoTimestamp) {
 	var success bool
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		labels := prometheus.Labels{"success": strconv.FormatBool(success)}
+		labels := prometheus.Labels{"success": strconv.FormatBool(success), "source": "mongo"}
 		routeReloadDurationMetric.With(labels).Observe(v)
 	}))
 	defer func() {
@@ -244,7 +244,7 @@ func (rt *Router) reloadRoutes(db *mgo.Database, currentOptime bson.MongoTimesta
 	rt.lock.Unlock()
 
 	logInfo(fmt.Sprintf("router: reloaded %d routes", routeCount))
-	routesCountMetric.Set(float64(routeCount))
+	routesCountMetric.WithLabelValues("mongo").Set(float64(routeCount))
 }
 
 func (rt *Router) getCurrentMongoInstance(db mongoDatabase) (MongoReplicaSetMember, error) {


### PR DESCRIPTION
This allows us to differentiate the reload duration and route count when loading from the content-store vs mongo.