### PR TITLE
Load backends from env vars

### DIFF
--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -20,7 +20,14 @@ var _ = BeforeSuite(func() {
 	if err != nil {
 		Fail(err.Error())
 	}
-	err = startRouter(routerPort, apiPort, nil)
+
+	backendEnvVars := []string{}
+	for id, host := range backends {
+		envVar := "BACKEND_URL_" + id + "=http://" + host
+		backendEnvVars = append(backendEnvVars, envVar)
+	}
+
+	err = startRouter(routerPort, apiPort, backendEnvVars)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/integration_tests/performance_test.go
+++ b/integration_tests/performance_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"net/http/httptest"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,15 +23,15 @@ var _ = Describe("Performance", func() {
 		BeforeEach(func() {
 			backend1 = startSimpleBackend("backend 1")
 			backend2 = startSimpleBackend("backend 2")
-			addBackend("backend-1", backend1.URL)
-			addBackend("backend-2", backend2.URL)
+			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
+			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
 			addRoute("/one", NewBackendRoute("backend-1"))
 			addRoute("/two", NewBackendRoute("backend-2"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			backend1.Close()
-			backend2.Close()
+			os.Unsetenv("BACKEND_URL_backend-1")
+			os.Unsetenv("BACKEND_URL_backend-2")
 		})
 
 		It("Router should not cause errors or much latency", func() {
@@ -60,7 +61,8 @@ var _ = Describe("Performance", func() {
 			It("Router should not cause errors or much latency", func() {
 				slowBackend := startTarpitBackend(time.Second)
 				defer slowBackend.Close()
-				addBackend("backend-slow", slowBackend.URL)
+				os.Setenv("BACKEND_URL_backend-slow", slowBackend.URL)
+				defer os.Unsetenv("BACKEND_URL_backend-slow")
 				addRoute("/slow", NewBackendRoute("backend-slow"))
 				reloadRoutes(apiPort)
 
@@ -73,7 +75,9 @@ var _ = Describe("Performance", func() {
 
 		Describe("with one downed backend hit separately", func() {
 			It("Router should not cause errors or much latency", func() {
-				addBackend("backend-down", "http://127.0.0.1:3162/")
+				os.Setenv("BACKEND_URL_backend-down", "http://127.0.0.1:3162/")
+				defer os.Unsetenv("BACKEND_URL_backend-down")
+
 				addRoute("/down", NewBackendRoute("backend-down"))
 				reloadRoutes(apiPort)
 
@@ -98,13 +102,15 @@ var _ = Describe("Performance", func() {
 		BeforeEach(func() {
 			backend1 = startTarpitBackend(time.Second)
 			backend2 = startTarpitBackend(time.Second)
-			addBackend("backend-1", backend1.URL)
-			addBackend("backend-2", backend2.URL)
+			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
+			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
 			addRoute("/one", NewBackendRoute("backend-1"))
 			addRoute("/two", NewBackendRoute("backend-2"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_backend-1")
+			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})

--- a/integration_tests/performance_test.go
+++ b/integration_tests/performance_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"net/http/httptest"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,17 +20,15 @@ var _ = Describe("Performance", func() {
 		)
 
 		BeforeEach(func() {
-			backend1 = startSimpleBackend("backend 1")
-			backend2 = startSimpleBackend("backend 2")
-			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
-			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
+			backend1 = startSimpleBackend("backend 1", backends["backend-1"])
+			backend2 = startSimpleBackend("backend 2", backends["backend-2"])
 			addRoute("/one", NewBackendRoute("backend-1"))
 			addRoute("/two", NewBackendRoute("backend-2"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend-1")
-			os.Unsetenv("BACKEND_URL_backend-2")
+			backend1.Close()
+			backend2.Close()
 		})
 
 		It("Router should not cause errors or much latency", func() {
@@ -59,11 +56,9 @@ var _ = Describe("Performance", func() {
 
 		Describe("with one slow backend hit separately", func() {
 			It("Router should not cause errors or much latency", func() {
-				slowBackend := startTarpitBackend(time.Second)
+				slowBackend := startTarpitBackend(backends["slow-1"], time.Second)
 				defer slowBackend.Close()
-				os.Setenv("BACKEND_URL_backend-slow", slowBackend.URL)
-				defer os.Unsetenv("BACKEND_URL_backend-slow")
-				addRoute("/slow", NewBackendRoute("backend-slow"))
+				addRoute("/slow", NewBackendRoute("slow-1"))
 				reloadRoutes(apiPort)
 
 				_, gen := generateLoad([]string{routerURL(routerPort, "/slow")}, 50)
@@ -75,10 +70,7 @@ var _ = Describe("Performance", func() {
 
 		Describe("with one downed backend hit separately", func() {
 			It("Router should not cause errors or much latency", func() {
-				os.Setenv("BACKEND_URL_backend-down", "http://127.0.0.1:3162/")
-				defer os.Unsetenv("BACKEND_URL_backend-down")
-
-				addRoute("/down", NewBackendRoute("backend-down"))
+				addRoute("/down", NewBackendRoute("down"))
 				reloadRoutes(apiPort)
 
 				_, gen := generateLoad([]string{routerURL(routerPort, "/down")}, 50)
@@ -100,17 +92,13 @@ var _ = Describe("Performance", func() {
 		var backend2 *httptest.Server
 
 		BeforeEach(func() {
-			backend1 = startTarpitBackend(time.Second)
-			backend2 = startTarpitBackend(time.Second)
-			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
-			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
-			addRoute("/one", NewBackendRoute("backend-1"))
-			addRoute("/two", NewBackendRoute("backend-2"))
+			backend1 = startTarpitBackend(backends["slow-1"], time.Second)
+			backend2 = startTarpitBackend(backends["slow-2"], time.Second)
+			addRoute("/one", NewBackendRoute("slow-1"))
+			addRoute("/two", NewBackendRoute("slow-2"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend-1")
-			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})

--- a/integration_tests/proxy_function_test.go
+++ b/integration_tests/proxy_function_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -20,9 +19,6 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 	Describe("connecting to the backend", func() {
 		It("should return a 502 if the connection to the backend is refused", func() {
-			os.Setenv("BACKEND_URL_not-running", "http://127.0.0.1:3164/")
-			defer os.Unsetenv("BACKEND_URL_not-running")
-
 			addRoute("/not-running", NewBackendRoute("not-running"))
 			reloadRoutes(apiPort)
 
@@ -34,22 +30,19 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 			logDetails := lastRouterErrorLogEntry()
 			Expect(logDetails.Fields).To(Equal(map[string]interface{}{
-				"error":          "dial tcp 127.0.0.1:3164: connect: connection refused",
+				"error":          "dial tcp 127.0.0.1:6803: connect: connection refused",
 				"request":        "GET /not-running HTTP/1.1",
 				"request_method": "GET",
 				"status":         float64(502), // All numbers in JSON are floating point
-				"upstream_addr":  "127.0.0.1:3164",
+				"upstream_addr":  "127.0.0.1:6803",
 			}))
 			Expect(logDetails.Timestamp).To(BeTemporally("~", time.Now(), time.Second))
 		})
 
 		It("should log and return a 504 if the connection times out in the configured time", func() {
-			err := startRouter(3167, 3166, []string{"ROUTER_BACKEND_CONNECT_TIMEOUT=0.3s"})
+			err := startRouter(3167, 3166, []string{"ROUTER_BACKEND_CONNECT_TIMEOUT=0.3s", "BACKEND_URL_black-hole=http://240.0.0.0:1234/"})
 			Expect(err).NotTo(HaveOccurred())
 			defer stopRouter(3167)
-
-			os.Setenv("BACKEND_URL_black-hole", "http://240.0.0.0:1234/")
-			defer os.Unsetenv("BACKEND_URL_black-hole")
 
 			addRoute("/should-time-out", NewBackendRoute("black-hole"))
 			reloadRoutes(3166)
@@ -79,20 +72,16 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 			var tarpit1, tarpit2 *httptest.Server
 
 			BeforeEach(func() {
-				err := startRouter(3167, 3166, []string{"ROUTER_BACKEND_HEADER_TIMEOUT=0.3s"})
+				err := startRouter(3167, 3166, []string{"ROUTER_BACKEND_HEADER_TIMEOUT=0.3s", "BACKEND_URL_slow-1=http://127.0.0.1:6256/", "BACKEND_URL_slow-2=http://127.0.0.1:6253/"})
 				Expect(err).NotTo(HaveOccurred())
-				tarpit1 = startTarpitBackend(time.Second)
-				tarpit2 = startTarpitBackend(100*time.Millisecond, 500*time.Millisecond)
-				os.Setenv("BACKEND_URL_tarpit1", tarpit1.URL)
-				os.Setenv("BACKEND_URL_tarpit2", tarpit2.URL)
-				addRoute("/tarpit1", NewBackendRoute("tarpit1"))
-				addRoute("/tarpit2", NewBackendRoute("tarpit2"))
+				tarpit1 = startTarpitBackend("127.0.0.1:6256", time.Second)
+				tarpit2 = startTarpitBackend("127.0.0.1:6253", 100*time.Millisecond, 500*time.Millisecond)
+				addRoute("/tarpit1", NewBackendRoute("slow-1"))
+				addRoute("/tarpit2", NewBackendRoute("slow-2"))
 				reloadRoutes(3166)
 			})
 
 			AfterEach(func() {
-				os.Unsetenv("BACKEND_URL_tarpit1")
-				os.Unsetenv("BACKEND_URL_tarpit2")
 				tarpit1.Close()
 				tarpit2.Close()
 				stopRouter(3167)
@@ -125,14 +114,12 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 	Describe("header handling", func() {
 		BeforeEach(func() {
-			recorder = startRecordingBackend()
-			os.Setenv("BACKEND_URL_backend", recorder.URL())
+			recorder = startRecordingBackend(false, backends["backend"])
 			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes(apiPort)
 		})
 
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend")
 			recorder.Close()
 		})
 
@@ -250,14 +237,12 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 	Describe("request verb, path, query and body handling", func() {
 		BeforeEach(func() {
-			recorder = startRecordingBackend()
-			os.Setenv("BACKEND_URL_backend", recorder.URL())
+			recorder = startRecordingBackend(false, backends["backend"])
 			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes(apiPort)
 		})
 
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend")
 			recorder.Close()
 		})
 
@@ -307,19 +292,20 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 	Describe("handling a backend with a non '/' path", func() {
 		BeforeEach(func() {
-			recorder = startRecordingBackend()
-			os.Setenv("BACKEND_URL_backend", recorder.URL()+"/something")
-			addRoute("/foo/bar", NewBackendRoute("backend", "prefix"))
-			reloadRoutes(apiPort)
+			err := startRouter(3167, 3166, []string{"ROUTER_TLS_SKIP_VERIFY=1", "BACKEND_URL_with-path=http://127.0.0.1:6804/something"})
+			Expect(err).NotTo(HaveOccurred())
+			recorder = startRecordingBackend(false, backends["with-path"])
+			addRoute("/foo/bar", NewBackendRoute("with-path", "prefix"))
+			reloadRoutes(3166)
 		})
 
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend")
 			recorder.Close()
+			stopRouter(3167)
 		})
 
 		It("should merge the 2 paths", func() {
-			resp := routerRequest(routerPort, "/foo/bar")
+			resp := routerRequest(3167, "/foo/bar")
 			Expect(resp.StatusCode).To(Equal(200))
 
 			Expect(recorder.ReceivedRequests()).To(HaveLen(1))
@@ -328,7 +314,7 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 		})
 
 		It("should preserve the request query string", func() {
-			resp := routerRequest(routerPort, "/foo/bar?baz=qux")
+			resp := routerRequest(3167, "/foo/bar?baz=qux")
 			Expect(resp.StatusCode).To(Equal(200))
 
 			Expect(recorder.ReceivedRequests()).To(HaveLen(1))
@@ -339,14 +325,12 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 	Describe("handling HTTP/1.0 requests", func() {
 		BeforeEach(func() {
-			recorder = startRecordingBackend()
-			os.Setenv("BACKEND_URL_backend", recorder.URL())
+			recorder = startRecordingBackend(false, backends["backend"])
 			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes(apiPort)
 		})
 
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend")
 			recorder.Close()
 		})
 
@@ -373,16 +357,14 @@ var _ = Describe("Functioning as a reverse proxy", func() {
 
 	Describe("handling requests to a HTTPS backend", func() {
 		BeforeEach(func() {
-			err := startRouter(3167, 3166, []string{"ROUTER_TLS_SKIP_VERIFY=1"})
+			err := startRouter(3167, 3166, []string{"ROUTER_TLS_SKIP_VERIFY=1", "BACKEND_URL_backend=https://127.0.0.1:2486"})
 			Expect(err).NotTo(HaveOccurred())
-			recorder = startRecordingTLSBackend()
-			os.Setenv("BACKEND_URL_backend", recorder.URL())
+			recorder = startRecordingBackend(true, "127.0.0.1:2486")
 			addRoute("/foo", NewBackendRoute("backend", "prefix"))
 			reloadRoutes(3166)
 		})
 
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend")
 			recorder.Close()
 			stopRouter(3167)
 		})

--- a/integration_tests/redirect_test.go
+++ b/integration_tests/redirect_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -223,13 +224,14 @@ var _ = Describe("Redirection", func() {
 
 		BeforeEach(func() {
 			recorder = startRecordingBackend()
-			addBackend("be", recorder.URL())
+			os.Setenv("BACKEND_URL_be", recorder.URL())
 			addRoute("/guidance/keeping-a-pet-pig-or-micropig", NewBackendRoute("be", "exact"))
 			addRoute("/GUIDANCE/keeping-a-pet-pig-or-micropig", NewBackendRoute("be", "exact"))
 			reloadRoutes(apiPort)
 		})
 
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_be")
 			recorder.Close()
 		})
 

--- a/integration_tests/redirect_test.go
+++ b/integration_tests/redirect_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -223,15 +222,13 @@ var _ = Describe("Redirection", func() {
 		var recorder *ghttp.Server
 
 		BeforeEach(func() {
-			recorder = startRecordingBackend()
-			os.Setenv("BACKEND_URL_be", recorder.URL())
+			recorder = startRecordingBackend(false, backends["be"])
 			addRoute("/guidance/keeping-a-pet-pig-or-micropig", NewBackendRoute("be", "exact"))
 			addRoute("/GUIDANCE/keeping-a-pet-pig-or-micropig", NewBackendRoute("be", "exact"))
 			reloadRoutes(apiPort)
 		})
 
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_be")
 			recorder.Close()
 		})
 

--- a/integration_tests/route_helpers.go
+++ b/integration_tests/route_helpers.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
 
 	// revive:disable:dot-imports
 	. "github.com/onsi/ginkgo/v2"
@@ -89,11 +88,6 @@ func initRouteHelper() error {
 
 	routerDB = sess.DB("router_test")
 	return nil
-}
-
-func addBackend(id, url string) {
-	err := routerDB.C("backends").Insert(bson.M{"backend_id": id, "backend_url": url})
-	Expect(err).NotTo(HaveOccurred())
 }
 
 func addRoute(path string, route Route) {

--- a/integration_tests/route_loading_test.go
+++ b/integration_tests/route_loading_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"net/http/httptest"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,14 +14,10 @@ var _ = Describe("loading routes from the db", func() {
 	)
 
 	BeforeEach(func() {
-		backend1 = startSimpleBackend("backend 1")
-		backend2 = startSimpleBackend("backend 2")
-		os.Setenv("BACKEND_URL_backend-1", backend1.URL)
-		os.Setenv("BACKEND_URL_backend-2", backend2.URL)
+		backend1 = startSimpleBackend("backend 1", backends["backend-1"])
+		backend2 = startSimpleBackend("backend 2", backends["backend-2"])
 	})
 	AfterEach(func() {
-		os.Unsetenv("BACKEND_URL_backend-1")
-		os.Unsetenv("BACKEND_URL_backend-2")
 		backend1.Close()
 		backend2.Close()
 	})

--- a/integration_tests/route_selection_test.go
+++ b/integration_tests/route_selection_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"net/http/httptest"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,14 +20,16 @@ var _ = Describe("Route selection", func() {
 		BeforeEach(func() {
 			backend1 = startSimpleBackend("backend 1")
 			backend2 = startSimpleBackend("backend 2")
-			addBackend("backend-1", backend1.URL)
-			addBackend("backend-2", backend2.URL)
+			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
+			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
 			addRoute("/foo", NewBackendRoute("backend-1"))
 			addRoute("/bar", NewBackendRoute("backend-2"))
 			addRoute("/baz", NewBackendRoute("backend-1"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_backend-1")
+			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})
@@ -68,14 +71,16 @@ var _ = Describe("Route selection", func() {
 		BeforeEach(func() {
 			backend1 = startSimpleBackend("backend 1")
 			backend2 = startSimpleBackend("backend 2")
-			addBackend("backend-1", backend1.URL)
-			addBackend("backend-2", backend2.URL)
+			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
+			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
 			addRoute("/foo", NewBackendRoute("backend-1", "prefix"))
 			addRoute("/bar", NewBackendRoute("backend-2", "prefix"))
 			addRoute("/baz", NewBackendRoute("backend-1", "prefix"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_backend-1")
+			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})
@@ -123,12 +128,14 @@ var _ = Describe("Route selection", func() {
 		BeforeEach(func() {
 			outer = startSimpleBackend("outer")
 			inner = startSimpleBackend("inner")
-			addBackend("outer-backend", outer.URL)
-			addBackend("inner-backend", inner.URL)
+			os.Setenv("BACKEND_URL_outer-backend", outer.URL)
+			os.Setenv("BACKEND_URL_inner-backend", inner.URL)
 			addRoute("/foo", NewBackendRoute("outer-backend", "prefix"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_outer-backend")
+			os.Unsetenv("BACKEND_URL_inner-backend")
 			outer.Close()
 			inner.Close()
 		})
@@ -191,12 +198,13 @@ var _ = Describe("Route selection", func() {
 			)
 			BeforeEach(func() {
 				innerer = startSimpleBackend("innerer")
-				addBackend("innerer-backend", innerer.URL)
+				os.Setenv("BACKEND_URL_innerer-backend", innerer.URL)
 				addRoute("/foo/bar", NewBackendRoute("inner-backend"))
 				addRoute("/foo/bar/baz", NewBackendRoute("innerer-backend", "prefix"))
 				reloadRoutes(apiPort)
 			})
 			AfterEach(func() {
+				os.Unsetenv("BACKEND_URL_innerer-backend")
 				innerer.Close()
 			})
 
@@ -245,13 +253,15 @@ var _ = Describe("Route selection", func() {
 		BeforeEach(func() {
 			backend1 = startSimpleBackend("backend 1")
 			backend2 = startSimpleBackend("backend 2")
-			addBackend("backend-1", backend1.URL)
-			addBackend("backend-2", backend2.URL)
+			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
+			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
 			addRoute("/foo", NewBackendRoute("backend-1", "prefix"))
 			addRoute("/foo", NewBackendRoute("backend-2"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_backend-1")
+			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})
@@ -276,11 +286,13 @@ var _ = Describe("Route selection", func() {
 		BeforeEach(func() {
 			root = startSimpleBackend("root backend")
 			other = startSimpleBackend("other backend")
-			addBackend("root", root.URL)
-			addBackend("other", other.URL)
+			os.Setenv("BACKEND_URL_root", root.URL)
+			os.Setenv("BACKEND_URL_other", other.URL)
 			addRoute("/foo", NewBackendRoute("other"))
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_root")
+			os.Unsetenv("BACKEND_URL_other")
 			root.Close()
 			other.Close()
 		})
@@ -323,13 +335,15 @@ var _ = Describe("Route selection", func() {
 		BeforeEach(func() {
 			root = startSimpleBackend("fallthrough")
 			recorder = startRecordingBackend()
-			addBackend("root", root.URL)
-			addBackend("other", recorder.URL())
+			os.Setenv("BACKEND_URL_root", root.URL)
+			os.Setenv("BACKEND_URL_other", recorder.URL())
 			addRoute("/", NewBackendRoute("root", "prefix"))
 			addRoute("/foo/bar", NewBackendRoute("other", "prefix"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_root")
+			os.Unsetenv("BACKEND_URL_other")
 			root.Close()
 			recorder.Close()
 		})
@@ -359,9 +373,10 @@ var _ = Describe("Route selection", func() {
 
 		BeforeEach(func() {
 			recorder = startRecordingBackend()
-			addBackend("backend", recorder.URL())
+			os.Setenv("BACKEND_URL_backend", recorder.URL())
 		})
 		AfterEach(func() {
+			os.Unsetenv("BACKEND_URL_backend")
 			recorder.Close()
 		})
 

--- a/integration_tests/route_selection_test.go
+++ b/integration_tests/route_selection_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"net/http/httptest"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,18 +17,14 @@ var _ = Describe("Route selection", func() {
 		)
 
 		BeforeEach(func() {
-			backend1 = startSimpleBackend("backend 1")
-			backend2 = startSimpleBackend("backend 2")
-			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
-			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
+			backend1 = startSimpleBackend("backend 1", backends["backend-1"])
+			backend2 = startSimpleBackend("backend 2", backends["backend-2"])
 			addRoute("/foo", NewBackendRoute("backend-1"))
 			addRoute("/bar", NewBackendRoute("backend-2"))
 			addRoute("/baz", NewBackendRoute("backend-1"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend-1")
-			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})
@@ -69,18 +64,14 @@ var _ = Describe("Route selection", func() {
 		)
 
 		BeforeEach(func() {
-			backend1 = startSimpleBackend("backend 1")
-			backend2 = startSimpleBackend("backend 2")
-			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
-			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
+			backend1 = startSimpleBackend("backend 1", backends["backend-1"])
+			backend2 = startSimpleBackend("backend 2", backends["backend-2"])
 			addRoute("/foo", NewBackendRoute("backend-1", "prefix"))
 			addRoute("/bar", NewBackendRoute("backend-2", "prefix"))
 			addRoute("/baz", NewBackendRoute("backend-1", "prefix"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend-1")
-			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})
@@ -126,23 +117,19 @@ var _ = Describe("Route selection", func() {
 		)
 
 		BeforeEach(func() {
-			outer = startSimpleBackend("outer")
-			inner = startSimpleBackend("inner")
-			os.Setenv("BACKEND_URL_outer-backend", outer.URL)
-			os.Setenv("BACKEND_URL_inner-backend", inner.URL)
-			addRoute("/foo", NewBackendRoute("outer-backend", "prefix"))
+			outer = startSimpleBackend("outer", backends["outer"])
+			inner = startSimpleBackend("inner", backends["inner"])
+			addRoute("/foo", NewBackendRoute("outer", "prefix"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_outer-backend")
-			os.Unsetenv("BACKEND_URL_inner-backend")
 			outer.Close()
 			inner.Close()
 		})
 
 		Describe("with an exact child", func() {
 			BeforeEach(func() {
-				addRoute("/foo/bar", NewBackendRoute("inner-backend"))
+				addRoute("/foo/bar", NewBackendRoute("inner"))
 				reloadRoutes(apiPort)
 			})
 
@@ -164,7 +151,7 @@ var _ = Describe("Route selection", func() {
 
 		Describe("with a prefix child", func() {
 			BeforeEach(func() {
-				addRoute("/foo/bar", NewBackendRoute("inner-backend", "prefix"))
+				addRoute("/foo/bar", NewBackendRoute("inner", "prefix"))
 				reloadRoutes(apiPort)
 			})
 
@@ -197,14 +184,12 @@ var _ = Describe("Route selection", func() {
 				innerer *httptest.Server
 			)
 			BeforeEach(func() {
-				innerer = startSimpleBackend("innerer")
-				os.Setenv("BACKEND_URL_innerer-backend", innerer.URL)
-				addRoute("/foo/bar", NewBackendRoute("inner-backend"))
-				addRoute("/foo/bar/baz", NewBackendRoute("innerer-backend", "prefix"))
+				innerer = startSimpleBackend("innerer", backends["innerer"])
+				addRoute("/foo/bar", NewBackendRoute("inner"))
+				addRoute("/foo/bar/baz", NewBackendRoute("innerer", "prefix"))
 				reloadRoutes(apiPort)
 			})
 			AfterEach(func() {
-				os.Unsetenv("BACKEND_URL_innerer-backend")
 				innerer.Close()
 			})
 
@@ -251,17 +236,13 @@ var _ = Describe("Route selection", func() {
 		)
 
 		BeforeEach(func() {
-			backend1 = startSimpleBackend("backend 1")
-			backend2 = startSimpleBackend("backend 2")
-			os.Setenv("BACKEND_URL_backend-1", backend1.URL)
-			os.Setenv("BACKEND_URL_backend-2", backend2.URL)
+			backend1 = startSimpleBackend("backend 1", backends["backend-1"])
+			backend2 = startSimpleBackend("backend 2", backends["backend-2"])
 			addRoute("/foo", NewBackendRoute("backend-1", "prefix"))
 			addRoute("/foo", NewBackendRoute("backend-2"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend-1")
-			os.Unsetenv("BACKEND_URL_backend-2")
 			backend1.Close()
 			backend2.Close()
 		})
@@ -284,15 +265,11 @@ var _ = Describe("Route selection", func() {
 		)
 
 		BeforeEach(func() {
-			root = startSimpleBackend("root backend")
-			other = startSimpleBackend("other backend")
-			os.Setenv("BACKEND_URL_root", root.URL)
-			os.Setenv("BACKEND_URL_other", other.URL)
+			root = startSimpleBackend("root backend", backends["root"])
+			other = startSimpleBackend("other backend", backends["other"])
 			addRoute("/foo", NewBackendRoute("other"))
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_root")
-			os.Unsetenv("BACKEND_URL_other")
 			root.Close()
 			other.Close()
 		})
@@ -333,17 +310,13 @@ var _ = Describe("Route selection", func() {
 		)
 
 		BeforeEach(func() {
-			root = startSimpleBackend("fallthrough")
-			recorder = startRecordingBackend()
-			os.Setenv("BACKEND_URL_root", root.URL)
-			os.Setenv("BACKEND_URL_other", recorder.URL())
-			addRoute("/", NewBackendRoute("root", "prefix"))
+			root = startSimpleBackend("fallthrough", backends["fallthrough"])
+			recorder = startRecordingBackend(false, backends["other"])
+			addRoute("/", NewBackendRoute("fallthrough", "prefix"))
 			addRoute("/foo/bar", NewBackendRoute("other", "prefix"))
 			reloadRoutes(apiPort)
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_root")
-			os.Unsetenv("BACKEND_URL_other")
 			root.Close()
 			recorder.Close()
 		})
@@ -372,11 +345,9 @@ var _ = Describe("Route selection", func() {
 		var recorder *ghttp.Server
 
 		BeforeEach(func() {
-			recorder = startRecordingBackend()
-			os.Setenv("BACKEND_URL_backend", recorder.URL())
+			recorder = startRecordingBackend(false, backends["backend"])
 		})
 		AfterEach(func() {
-			os.Unsetenv("BACKEND_URL_backend")
 			recorder.Close()
 		})
 

--- a/lib/backends.go
+++ b/lib/backends.go
@@ -1,0 +1,49 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/alphagov/router/handlers"
+	"github.com/alphagov/router/logger"
+)
+
+func loadBackendsFromEnv(connTimeout, headerTimeout time.Duration, logger logger.Logger) (backends map[string]http.Handler) {
+	backends = make(map[string]http.Handler)
+
+	for _, envvar := range os.Environ() {
+		pair := strings.SplitN(envvar, "=", 2)
+
+		if !strings.HasPrefix(pair[0], "BACKEND_URL_") {
+			continue
+		}
+
+		backendID := strings.TrimPrefix(pair[0], "BACKEND_URL_")
+		backendURL := pair[1]
+
+		if backendURL == "" {
+			logWarn(fmt.Errorf("router: couldn't find URL for backend %s, skipping", backendID))
+			continue
+		}
+
+		backend, err := url.Parse(backendURL)
+		if err != nil {
+			logWarn(fmt.Errorf("router: couldn't parse URL %s for backend %s (error: %w), skipping", backendURL, backendID, err))
+			continue
+		}
+
+		backends[backendID] = handlers.NewBackendHandler(
+			backendID,
+			backend,
+			connTimeout,
+			headerTimeout,
+			logger,
+		)
+	}
+
+	return
+}

--- a/lib/backends_test.go
+++ b/lib/backends_test.go
@@ -1,0 +1,41 @@
+package router
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Backends", func() {
+	Context("When calling loadBackendsFromEnv", func() {
+		It("should load backends from environment variables", func() {
+			os.Setenv("BACKEND_URL_testBackend", "http://example.com")
+			defer os.Unsetenv("BACKEND_URL_testBackend")
+
+			backends := loadBackendsFromEnv(1*time.Second, 20*time.Second, nil)
+
+			Expect(backends).To(HaveKey("testBackend"))
+			Expect(backends["testBackend"]).ToNot(BeNil())
+		})
+
+		It("should skip backends with empty URLs", func() {
+			os.Setenv("BACKEND_URL_emptyBackend", "")
+			defer os.Unsetenv("BACKEND_URL_emptyBackend")
+
+			backends := loadBackendsFromEnv(1*time.Second, 20*time.Second, nil)
+
+			Expect(backends).ToNot(HaveKey("emptyBackend"))
+		})
+
+		It("should skip backends with invalid URLs", func() {
+			os.Setenv("BACKEND_URL_invalidBackend", "://invalid-url")
+			defer os.Unsetenv("BACKEND_URL_invalidBackend")
+
+			backends := loadBackendsFromEnv(1*time.Second, 20*time.Second, nil)
+
+			Expect(backends).ToNot(HaveKey("invalidBackend"))
+		})
+	})
+})


### PR DESCRIPTION
As we only have a small number of backends that change infrequently, their URL configuration can be handled by environment variables. This allows us to remove a dependency from using the Mongo Database to fetch this information and allows us to using the Content Store for route information.

Router will use any environment variable with the prefix "BACKEND_URL_", where the key suffix is the backend id and the value is the URL.