### PR TITLE
Improve periodic reload

### DIFF
--- a/lib/router.go
+++ b/lib/router.go
@@ -42,18 +42,18 @@ const (
 // come from, Route and Backend should not contain bson fields.
 // MongoReplicaSet, MongoReplicaSetMember etc. should move out of this module.
 type Router struct {
-	backends          map[string]http.Handler
-	mux               *triemux.Mux
-	csMux             *triemux.Mux
-	lock              sync.RWMutex
-	mongoReadToOptime bson.MongoTimestamp
-	logger            logger.Logger
-	opts              Options
-	ReloadChan        chan bool
-	CsReloadChan      chan bool
-	csMuxSampleRate   float64
-	csLastReloadTime  time.Time
-	pool              *pgxpool.Pool
+	backends                map[string]http.Handler
+	mux                     *triemux.Mux
+	csMux                   *triemux.Mux
+	lock                    sync.RWMutex
+	mongoReadToOptime       bson.MongoTimestamp
+	logger                  logger.Logger
+	opts                    Options
+	ReloadChan              chan bool
+	CsReloadChan            chan bool
+	csMuxSampleRate         float64
+	csLastAttemptReloadTime time.Time
+	pool                    *pgxpool.Pool
 }
 
 type Options struct {


### PR DESCRIPTION
Currently, it reloads every minute regardless if a reload has occurred within that minute. This is because we never set the last reload time. This also improves the responsiveness by checking for a periodic reload every 5 seconds, instead of a minute (which could potentially mean a reload could take up to 2 minutes).

Renamed csLastReloadTime to csLastAttemptReloadTime for clarity.

Tested in integration