### PR TITLE
Add version number 2.0.2 to golangci lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+        with:
+          version: v2.0.2


### PR DESCRIPTION
Description:
- Add version number 2.0.2 to golanci lint