### PR TITLE
Upload golangci lint to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        with:
+          version: v2.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
----
+version: "2"
 linters:
   enable:
     - asciicheck
@@ -20,19 +20,17 @@ linters:
     - promlinter
     - reassign
     - revive
-    - stylecheck
-    - tenv
     - tparallel
     - unconvert
     - usestdlibvars
     - wastedassign
     - zerologlint
-linters-settings:
-  revive:
-    rules:
-      - name: dot-imports
-        disabled: true  # Covered by stylecheck.
-  stylecheck:
-    dot-import-whitelist:
-      - github.com/onsi/ginkgo/v2
-      - github.com/onsi/gomega
+  settings:
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega


### PR DESCRIPTION
Description:
- Add version number 2.0.2 to golangci lint as this is now required
- Update golangci lint to v7