### PR TITLE
Update go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,10 +21,10 @@ linters:
     - reassign
     - revive
     - stylecheck
-    - tenv
     - tparallel
     - unconvert
     - usestdlibvars
+    - usetesting
     - wastedassign
     - zerologlint
 linters-settings:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG go_registry=""
-ARG go_version=1.23.5
+ARG go_version=1.24.4
 ARG go_tag_suffix=-alpine
 
 FROM --platform=$TARGETPLATFORM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/alphagov/router
 
-go 1.23.5
-
-toolchain go1.24.1
+go 1.24.4
 
 require (
 	github.com/getsentry/sentry-go v0.34.0


### PR DESCRIPTION
* golangci-lint was giving a warning telling us to use usetesting linter instead of tenv, so make that change
* Update go version in Dockerfile and go.mod (using `go mod edit -go=1.24.4` and then `go mod tidy`)
* I ran the tests which passed, but seem a little flaky (even on main)