### PR TITLE
Resolve lint errors for functions without contexts

### DIFF
--- a/integration_tests/backend_helpers.go
+++ b/integration_tests/backend_helpers.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -32,7 +33,8 @@ var backends = map[string]string{
 }
 
 func startSimpleBackend(identifier, host string) *httptest.Server {
-	l, err := net.Listen("tcp", host)
+	listenConfig := net.ListenConfig{}
+	l, err := listenConfig.Listen(context.Background(), "tcp", host)
 	Expect(err).NotTo(HaveOccurred())
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +57,8 @@ func startTarpitBackend(host string, delays ...time.Duration) *httptest.Server {
 		bodyDelay = delays[1]
 	}
 
-	l, err := net.Listen("tcp", host)
+	listenConfig := net.ListenConfig{}
+	l, err := listenConfig.Listen(context.Background(), "tcp", host)
 	Expect(err).NotTo(HaveOccurred())
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -81,7 +84,8 @@ func startTarpitBackend(host string, delays ...time.Duration) *httptest.Server {
 }
 
 func startRecordingBackend(tls bool, host string) *ghttp.Server {
-	l, err := net.Listen("tcp", host)
+	listenConfig := net.ListenConfig{}
+	l, err := listenConfig.Listen(context.Background(), "tcp", host)
 	Expect(err).NotTo(HaveOccurred())
 
 	ts := ghttp.NewUnstartedServer()

--- a/integration_tests/http_request_helpers.go
+++ b/integration_tests/http_request_helpers.go
@@ -50,7 +50,8 @@ func doRequest(req *http.Request) *http.Response {
 }
 
 func doHTTP10Request(req *http.Request) *http.Response {
-	conn, err := net.Dial("tcp", req.URL.Host)
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(req.Context(), "tcp", req.URL.Host)
 	Expect(err).NotTo(HaveOccurred())
 
 	defer func() {


### PR DESCRIPTION
Since golangci-lint updated to 2.3 we are getting lint errors, including on main

Where we are using non-context versions of net.Listen, net.Dial, and exec.Command

This PR uses the versions of these functions which take a context, and sets it appropriately depending on the real context.

All of these are in tests, so if the tests pass this should be good to go.

See [this github actions lint failure](https://github.com/alphagov/router/actions/runs/16884080982/job/47827149450):
```
run golangci-lint
  Running [/home/runner/golangci-lint-2.3.1-linux-amd64/golangci-lint config path] in [/home/runner/work/router/router] ...
  Running [/home/runner/golangci-lint-2.3.1-linux-amd64/golangci-lint config verify] in [/home/runner/work/router/router] ...
  Running [/home/runner/golangci-lint-2.3.1-linux-amd64/golangci-lint run] in [/home/runner/work/router/router] ...
  Error: integration_tests/backend_helpers.go:35:22: net.Listen must not be called. use (*net.ListenConfig).Listen (noctx)
  	l, err := net.Listen("tcp", host)
  	                    ^
  Error: integration_tests/backend_helpers.go:58:22: net.Listen must not be called. use (*net.ListenConfig).Listen (noctx)
  	l, err := net.Listen("tcp", host)
  	                    ^
  Error: integration_tests/backend_helpers.go:84:22: net.Listen must not be called. use (*net.ListenConfig).Listen (noctx)
  	l, err := net.Listen("tcp", host)
  	                    ^
  Error: integration_tests/http_request_helpers.go:53:23: net.Dial must not be called. use (*net.Dialer).DialContext (noctx)
  	conn, err := net.Dial("tcp", req.URL.Host)
  	                     ^
  Error: integration_tests/router_support.go:91:21: os/exec.Command must not be called. use os/exec.CommandContext (noctx)
  	cmd := exec.Command(bin) //gosec:disable G204 -- We intentionally want to exec a sub process with a var
  	                   ^
  Error: integration_tests/router_support.go:127:24: net.Dial must not be called. use (*net.Dialer).DialContext (noctx)
  		conn, err := net.Dial("tcp", addr)
  		                     ^
  6 issues:
  * noctx: 6
```