### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,22 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 10
+...


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
