### PR TITLE
Add router-probe-backend backend which is loaded whether from the database or file

### DIFF
--- a/lib/load_routes.go
+++ b/lib/load_routes.go
@@ -104,6 +104,28 @@ func loadRoutes(pool PgxIface, mux *triemux.Mux, backends map[string]http.Handle
 	if err := rows.Err(); err != nil {
 		return err
 	}
+
+	err = addProbeRoute(mux, backends, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addProbeRoute(mux *triemux.Mux, backends map[string]http.Handler, logger zerolog.Logger) error {
+	route := &Route{
+		IncomingPath: new("/__probe__"),
+		RouteType:    new(RouteTypePrefix),
+		SchemaName:   new(HandlerTypeBackend),
+		BackendID:    new("router-probe-backend"),
+	}
+
+	err := addHandler(mux, route, backends, logger)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/lib/load_routes_file.go
+++ b/lib/load_routes_file.go
@@ -56,5 +56,10 @@ func loadRoutesFromFile(filePath string, mux *triemux.Mux, backends map[string]h
 		return fmt.Errorf("error reading routes file: %w", err)
 	}
 
+	err = addProbeRoute(mux, backends, logger)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/lib/load_routes_file_test.go
+++ b/lib/load_routes_file_test.go
@@ -1,7 +1,10 @@
 package router
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,6 +89,52 @@ this is not valid JSON
 	routeCount := mux.RouteCount()
 	if routeCount != 2 {
 		t.Errorf("Expected 2 routes (skipping invalid JSON), got %d", routeCount)
+	}
+}
+
+func TestLoadRoutesFromFile_IncludesProbe(t *testing.T) {
+
+	tmpDir := t.TempDir()
+	routesFile := filepath.Join(tmpDir, "test_no_routes.jsonl")
+
+	content := ``
+
+	if err := os.WriteFile(routesFile, []byte(content), 0600); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	logger := zerolog.Nop()
+	mux := triemux.NewMux(logger)
+	backends := map[string]http.Handler{
+		"router-probe-backend": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+
+			if _, err := w.Write([]byte("router-probe-backend")); err != nil {
+				fmt.Println("Failed to write to the response", err)
+			}
+		}),
+	}
+
+	err := loadRoutesFromFile(routesFile, mux, backends, logger)
+	if err != nil {
+		t.Fatalf("Failed to load routes from file: %v", err)
+	}
+
+	routeCount := mux.RouteCount()
+	if routeCount != 1 {
+		t.Errorf("Expected 1 routes, got %d", routeCount)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/__probe__/get", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected router-probe-backend to return 200 OK, got %v", rr.Code)
+	}
+
+	if rr.Body.String() != "router-probe-backend" {
+		t.Errorf("Expected router-probe-backend to be called and return expected result, got %v", rr.Body.String())
 	}
 }
 

--- a/lib/load_routes_test.go
+++ b/lib/load_routes_test.go
@@ -39,13 +39,19 @@ var _ = Describe("loadRoutes", func() {
 			}),
 			"backend2": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				if _, err:= w.Write([]byte("backend2")); err != nil {
+				if _, err := w.Write([]byte("backend2")); err != nil {
 					fmt.Println("Failed to write to the response", err)
 				}
 			}),
 			"frontend": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				if _, err:= w.Write([]byte("frontend")); err != nil {
+				if _, err := w.Write([]byte("frontend")); err != nil {
+					fmt.Println("Failed to write to the response", err)
+				}
+			}),
+			"router-probe-backend": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte("router-probe-backend")); err != nil {
 					fmt.Println("Failed to write to the response", err)
 				}
 			}),
@@ -213,6 +219,25 @@ var _ = Describe("loadRoutes", func() {
 
 			Expect(rr.Code).To(Equal(http.StatusMovedPermanently))
 			Expect(rr.Header().Get("Location")).To(Equal("/redirected-prefix-preserve/foo/bar"))
+		})
+	})
+
+	Context("should always load the backend-probe route", func() {
+		BeforeEach(func() {
+			rows := pgxmock.NewRows([]string{})
+			mockPool.ExpectQuery("WITH").WillReturnRows(rows)
+
+			err := loadRoutes(mockPool, mux, backends, logger)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should load the probe backend route correctly", func() {
+			req, _ := http.NewRequest(http.MethodGet, "/__probe__/get", nil)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(rr.Body.String()).To(Equal("router-probe-backend"))
 		})
 	})
 })


### PR DESCRIPTION
Add in a fixed `/__probe__` prefix route which will always route to the router-probe-backend backend.

Load this route in both the load from content store, and load from file startup paths