### PR TITLE
Add tests for signal handling

### DIFF
--- a/integration_tests/backend_helpers.go
+++ b/integration_tests/backend_helpers.go
@@ -30,6 +30,7 @@ var backends = map[string]string{
 	"be":          "127.0.0.1:6802",
 	"not-running": "127.0.0.1:6803",
 	"with-path":   "127.0.0.1:6804",
+	"signals-1":   "127.0.0.1:6805",
 }
 
 func startSimpleBackend(identifier, host string) *httptest.Server {

--- a/integration_tests/http_request_helpers.go
+++ b/integration_tests/http_request_helpers.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -14,6 +15,11 @@ import (
 	. "github.com/onsi/gomega"
 	// revive:enable:dot-imports
 )
+
+type AsyncResponse struct {
+	response *http.Response
+	err      error
+}
 
 func routerRequest(port int, path string) *http.Response {
 	return doRequest(newRequest(http.MethodGet, routerURL(port, path)))
@@ -47,6 +53,17 @@ func doRequest(req *http.Request) *http.Response {
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	Expect(err).NotTo(HaveOccurred())
 	return resp
+}
+
+func doRequestAsync(request *http.Request, responseChannel chan *AsyncResponse) {
+	client := &http.Client{}
+	httpResponse, httpError := client.Do(request) //gosec:disable G704 - It's not really a tainted url, it just comes from elsewhere in our code
+	bodyCloseErr := httpResponse.Body.Close()
+
+	responseChannel <- &AsyncResponse{
+		response: httpResponse,
+		err:      errors.Join(httpError, bodyCloseErr),
+	}
 }
 
 func doHTTP10Request(req *http.Request) *http.Response {

--- a/integration_tests/http_request_helpers.go
+++ b/integration_tests/http_request_helpers.go
@@ -58,11 +58,15 @@ func doRequest(req *http.Request) *http.Response {
 func doRequestAsync(request *http.Request, responseChannel chan *AsyncResponse) {
 	client := &http.Client{}
 	httpResponse, httpError := client.Do(request) //gosec:disable G704 - It's not really a tainted url, it just comes from elsewhere in our code
-	bodyCloseErr := httpResponse.Body.Close()
+
+	var bodyCloseError error
+	if httpResponse != nil {
+		bodyCloseError = httpResponse.Body.Close()
+	}
 
 	responseChannel <- &AsyncResponse{
 		response: httpResponse,
-		err:      errors.Join(httpError, bodyCloseErr),
+		err:      errors.Join(httpError, bodyCloseError),
 	}
 }
 

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -16,6 +16,18 @@ func TestEverything(t *testing.T) {
 	RunSpecs(t, "Integration test suite")
 }
 
+func StartupRouterForIntegrationTests(routerPort, apiPort int) {
+	backendEnvVars := []string{}
+	for id, host := range backends {
+		envVar := "BACKEND_URL_" + id + "=http://" + host
+		backendEnvVars = append(backendEnvVars, envVar)
+	}
+
+	if err := startRouter(routerPort, apiPort, backendEnvVars); err != nil {
+		Fail(err.Error())
+	}
+}
+
 var _ = BeforeSuite(func() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	var err error
@@ -28,15 +40,8 @@ var _ = BeforeSuite(func() {
 		Fail(err.Error())
 	}
 
-	backendEnvVars := []string{}
-	for id, host := range backends {
-		envVar := "BACKEND_URL_" + id + "=http://" + host
-		backendEnvVars = append(backendEnvVars, envVar)
-	}
+	StartupRouterForIntegrationTests(routerPort, apiPort)
 
-	if err := startRouter(routerPort, apiPort, backendEnvVars); err != nil {
-		Fail(err.Error())
-	}
 	if err := initRouteHelper(); err != nil {
 		Fail(err.Error())
 	}

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -118,6 +119,62 @@ func startRouter(port, apiPort int, extraEnv []string) error {
 
 	runningRouters[port] = cmd
 	return nil
+}
+
+func sendSignalToRouter(port int, sig os.Signal) (*exec.Cmd, error) {
+	router, ok := runningRouters[port]
+	if !ok {
+		return nil, fmt.Errorf("no running router on on port %d", port)
+	}
+
+	err := router.Process.Signal(sig)
+	if err != nil {
+		return nil, err
+	}
+
+	return router, nil
+}
+
+func ensureRouterTerminated(port int) error {
+	cmd, ok := runningRouters[port]
+	if !ok {
+		// Router has already been termianted and cleaned up, or was never created
+		return nil
+	}
+
+	if cmd.ProcessState != nil {
+		// The process already terminated, just cleanup
+		delete(runningRouters, port)
+		return nil
+	}
+
+	err := cmd.Process.Signal(syscall.SIGINT)
+	if errors.Is(err, os.ErrProcessDone) {
+		delete(runningRouters, port)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to send termination signal to running router process, error: %w", err)
+	}
+
+	state, err := cmd.Process.Wait()
+	waitStatus, ok := state.Sys().(syscall.WaitStatus)
+	if !ok {
+		return fmt.Errorf("could not convert process wait status to a syscall.WaitStatus, maybe you're not on a *nix platform?")
+	}
+
+	switch {
+	// On unix if a process exits because of a signal it will is not 'exited', instead it is 'signalled', either way we shut down fine
+	case state.Exited() || waitStatus.Signaled():
+		delete(runningRouters, port)
+		return nil
+	case err != nil:
+		return fmt.Errorf("running router process did not exit with error: %w", err)
+	default:
+		return fmt.Errorf(
+			"the running router process both did not exit, and did not return an error waiting for termination! The state was %s",
+			state,
+		)
+	}
 }
 
 func getCoverageDir() (string, error) {

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -138,7 +138,7 @@ func sendSignalToRouter(port int, sig os.Signal) (*exec.Cmd, error) {
 func ensureRouterTerminated(port int) error {
 	cmd, ok := runningRouters[port]
 	if !ok {
-		// Router has already been termianted and cleaned up, or was never created
+		// Router has already been terminated and cleaned up, or was never created
 		return nil
 	}
 
@@ -163,7 +163,7 @@ func ensureRouterTerminated(port int) error {
 	}
 
 	switch {
-	// On unix if a process exits because of a signal it will is not 'exited', instead it is 'signalled', either way we shut down fine
+	// On *nix if a process exits because of a signal it is not 'exited', instead it is 'signalled', either way we shut down fine
 	case state.Exited() || waitStatus.Signaled():
 		delete(runningRouters, port)
 		return nil

--- a/integration_tests/signal_handling_test.go
+++ b/integration_tests/signal_handling_test.go
@@ -1,0 +1,65 @@
+package integration
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"syscall"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = XDescribe("Signal Handling", func() {
+	const signalHandlingRouterPort = routerPort + 2
+	const signalHandlingApiPort = apiPort + 2
+
+	BeforeEach(func() {
+		StartupRouterForIntegrationTests(signalHandlingRouterPort, signalHandlingApiPort)
+	})
+
+	AfterEach(func() {
+		err := ensureRouterTerminated(signalHandlingRouterPort)
+		if err != nil {
+			log.Fatalf("Couldn't terminate router successfully, can't continue tests, error was: %s", err)
+		}
+	})
+
+	for _, signal := range []syscall.Signal{syscall.SIGINT, syscall.SIGTERM} {
+		Context(fmt.Sprintf("When receiving a %s", signal), func() {
+			It("Exits successfully", func() {
+				routerCmd, err := sendSignalToRouter(signalHandlingRouterPort, signal)
+				Expect(err).ToNot(HaveOccurred())
+				state, err := routerCmd.Process.Wait()
+				Expect(state.Success()).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("Gracefully allows connections to complete", func() {
+				// Use a backend request that takes 1 seconds to give us time to send the signal to router
+				slowBackend := startTarpitBackend(backends["signals-1"], time.Second)
+				defer slowBackend.Close()
+				addRoute("/signals", NewBackendRoute("signals-1"))
+				reloadRoutes(signalHandlingApiPort)
+
+				responseChannel := make(chan *AsyncResponse, 1)
+				go doRequestAsync(
+					newRequest(http.MethodGet, routerURL(signalHandlingRouterPort, "/signals")),
+					responseChannel,
+				)
+
+				// Sleep for just a little time to give the request chance to start
+				time.Sleep(time.Millisecond * 100)
+
+				_, err := sendSignalToRouter(signalHandlingRouterPort, signal)
+				Expect(err).ToNot(HaveOccurred())
+
+				response := <-responseChannel
+
+				Expect(response.err).ToNot(HaveOccurred())
+				Expect(response.response.StatusCode).To(Equal(200))
+			})
+		})
+	}
+})


### PR DESCRIPTION
Router isn't handling shutdown signals at all, so when a SIGINT or SIGTERM arrives all open connections are immediately severed and router exits non-zero.

I have a fix, but testing for it is a bit complex, so this PR adds in signal handling tests for SIGINT and SIGTERM but leaves them set as Pending (since they fail against main due to the lack of signal handling).

You can test these by checking this branch out and on line 14 of `integration_tests/signal_handling_test.go` remove the X from `XDescribe`, then run the integration tests: `make integration_tests`

You'll get the following results:

```
 $ make integration_tests
...SNIP...
go test -race -v ./integration_tests
=== RUN   TestEverything
Running Suite: Integration test suite - /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests
====================================================================================================================
Random Seed: 1777374964

Will run 116 of 116 specs
...SNIP...
------------------------------
• [FAILED] [0.122 seconds]
Signal Handling When receiving a interrupt [It] Exits successfully
/Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:31

  [FAILED] Expected
      <bool>: false
  to be true
  In [It] at: /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:35 @ 04/28/26 12:16:06.096
------------------------------
• [FAILED] [0.136 seconds]
Signal Handling When receiving a terminated [It] Exits successfully
/Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:31

  [FAILED] Expected
      <bool>: false
  to be true
  In [It] at: /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:35 @ 04/28/26 12:16:06.221
------------------------------
• [FAILED] [0.189 seconds]
Signal Handling When receiving a interrupt [It] Gracefully allows connections to complete
/Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:39

  [FAILED] Unexpected error:
      <*errors.joinError | 0xc0003e2090>:
      Get "http://127.0.0.1:3171/signals": read tcp 127.0.0.1:65527->127.0.0.1:3171: read: connection reset by peer
      {
          errs: [
              <*url.Error | 0xc0000d2210>{
                  Op: "Get",
                  URL: "http://127.0.0.1:3171/signals",
                  Err: <*net.OpError | 0xc000614280>{
                      Op: "read",
                      Net: "tcp",
                      Source: <*net.TCPAddr | 0xc000407e30>{IP: [127, 0, 0, 1], Port: 65527, Zone: ""},
                      Addr: <*net.TCPAddr | 0xc000407e60>{IP: [127, 0, 0, 1], Port: 3171, Zone: ""},
                      Err: <*os.SyscallError | 0xc000120140>{
                          Syscall: "read",
                          Err: <syscall.Errno>0x36,
                      },
                  },
              },
          ],
      }
  occurred
  In [It] at: /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:56 @ 04/28/26 12:16:06.423
------------------------------
• [FAILED] [0.324 seconds]
Signal Handling When receiving a terminated [It] Gracefully allows connections to complete
/Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:39

  [FAILED] Unexpected error:
      <*errors.joinError | 0xc0003e21b0>:
      Get "http://127.0.0.1:3171/signals": read tcp 127.0.0.1:49160->127.0.0.1:3171: read: connection reset by peer
      {
          errs: [
              <*url.Error | 0xc0000d2810>{
                  Op: "Get",
                  URL: "http://127.0.0.1:3171/signals",
                  Err: <*net.OpError | 0xc0000405a0>{
                      Op: "read",
                      Net: "tcp",
                      Source: <*net.TCPAddr | 0xc0000d2750>{IP: [127, 0, 0, 1], Port: 49160, Zone: ""},
                      Addr: <*net.TCPAddr | 0xc0000d2780>{IP: [127, 0, 0, 1], Port: 3171, Zone: ""},
                      Err: <*os.SyscallError | 0xc000600500>{
                          Syscall: "read",
                          Err: <syscall.Errno>0x36,
                      },
                  },
              },
          ],
      }
  occurred
  In [It] at: /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:56 @ 04/28/26 12:16:06.748
------------------------------
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
...SNIP...

Summarizing 4 Failures:
  [FAIL] Signal Handling When receiving a interrupt [It] Exits successfully
  /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:35
  [FAIL] Signal Handling When receiving a terminated [It] Exits successfully
  /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:35
  [FAIL] Signal Handling When receiving a interrupt [It] Gracefully allows connections to complete
  /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:56
  [FAIL] Signal Handling When receiving a terminated [It] Gracefully allows connections to complete
  /Users/jonathan.harden/gitdevel/github.com/alphagov/router/integration_tests/signal_handling_test.go:56

Ran 116 of 116 Specs in 82.179 seconds
FAIL! -- 112 Passed | 4 Failed | 0 Pending | 0 Skipped
--- FAIL: TestEverything (82.19s)
FAIL
FAIL	github.com/alphagov/router/integration_tests	82.715s
FAIL
make: *** [integration_tests] Error 1
```