### PR TITLE
Refactor the export integration test to actually run the router execu…

### DIFF
--- a/integration_tests/export_test.go
+++ b/integration_tests/export_test.go
@@ -3,15 +3,40 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	router "github.com/alphagov/router/lib"
-	"github.com/rs/zerolog"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func runRouterInExportRoutesMode(routesFileName string) error {
+	backgroundContext := context.Background()
+	coverageDir, err := getCoverageDir()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(backgroundContext, routerBinary(), "-export-routes") //gosec:disable G204 //gosec:disable G702-- We intentionally want to exec a sub process with a var
+
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOCOVERDIR=%s", coverageDir))
+	cmd.Env = append(
+		cmd.Env,
+		fmt.Sprintf("CONTENT_STORE_DATABASE_URL=%s", postgresContainer.MustConnectionString(backgroundContext)),
+	)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("ROUTER_ROUTES_FILE=%s", routesFileName))
+
+	if os.Getenv("ROUTER_DEBUG_TESTS") != "" {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	return cmd.Run()
+}
 
 var _ = Describe("Route Export", func() {
 	BeforeEach(func() {
@@ -22,10 +47,6 @@ var _ = Describe("Route Export", func() {
 	})
 
 	It("should export routes in JSONL format", func() {
-		ctx := context.Background()
-		err := os.Setenv("CONTENT_STORE_DATABASE_URL", postgresContainer.MustConnectionString(ctx))
-		Expect(err).NotTo(HaveOccurred())
-
 		// Create a temporary file for export
 		tmpFile, err := os.CreateTemp("", "routes-*.jsonl")
 		Expect(err).NotTo(HaveOccurred())
@@ -35,9 +56,7 @@ var _ = Describe("Route Export", func() {
 			_ = os.Remove(tmpFileName)
 		}()
 
-		logger := zerolog.Nop()
-
-		err = router.ExportRoutes(tmpFileName, logger)
+		err = runRouterInExportRoutesMode(tmpFileName)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Read the exported file
@@ -81,10 +100,7 @@ var _ = Describe("Route Export", func() {
 			_ = os.Remove(tmpFileName)
 		}()
 
-		logger := zerolog.Nop()
-
-		// Export routes
-		err = router.ExportRoutes(tmpFileName, logger)
+		err = runRouterInExportRoutesMode(tmpFileName)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Read the exported file

--- a/integration_tests/router_support.go
+++ b/integration_tests/router_support.go
@@ -82,17 +82,23 @@ func reloadRoutes(port int) {
 
 var runningRouters = make(map[int]*exec.Cmd)
 
+func routerBinary() string {
+	bin := os.Getenv("BINARY")
+
+	if bin == "" {
+		bin = "../router"
+	}
+
+	return bin
+}
+
 func startRouter(port, apiPort int, extraEnv []string) error {
 	host := "localhost"
 	pubAddr := net.JoinHostPort(host, strconv.Itoa(port))
 	apiAddr := net.JoinHostPort(host, strconv.Itoa(apiPort))
 
-	bin := os.Getenv("BINARY")
-	if bin == "" {
-		bin = "../router"
-	}
 	ctx := context.Background()
-	cmd := exec.CommandContext(ctx, bin) //gosec:disable G204 //gosec:disable G702-- We intentionally want to exec a sub process with a var
+	cmd := exec.CommandContext(ctx, routerBinary()) //gosec:disable G204 //gosec:disable G702-- We intentionally want to exec a sub process with a var
 
 	coverageDir, err := getCoverageDir()
 	if err != nil {


### PR DESCRIPTION
Requires https://github.com/alphagov/router/pull/679 to actually get the positive changes described below

Contributes towards https://github.com/alphagov/govuk-infrastructure/issues/3938

The router export test (which tests that router can export a jsonlines file of the routes (used when we need the content-store database to be offline so we can run router in a static mode)) sits in the integration directory, but it acts as a unit test (in that we don't execute router in export mode, instead we call the router libraries export function), but this means its coverage cannot be measured.

This is because integration tests are expected to be executing the router binary which has been built with coverage reporting, whereas unit tests are expecting to generate coverage as the tests are executed within the go test process. Since the integration tests don't run in go test -cover mode (and if they did it would largely measure the coverage of the integration testing directory, rather than the code under test), and the export tests are in integration tests we end up with 0 coverage reported 

You can see this in the following screenshot from the HTLM version of the coverage report)
<img width="438" height="60" alt="github.com/alphagov/router/lib/export_routes.go (0.0%)" src="https://github.com/user-attachments/assets/eb97bfb3-470e-4c2e-af8f-c9a2c490aac8" />

It means we also don't run the code paths in main which drive router in export mode, again seen in the screenshot below
<img width="1221" height="431" alt="A code listing from main.go with all code inside an if exportRoutes block highlighted red" src="https://github.com/user-attachments/assets/b412cc3a-bcca-4f0c-a152-fecfba824aac" />. In this case the coverage report showing no execution of these is correct since during the tests we never drive router via the main function to export the routes.

So this PR:

* Refactors the export test to drive router by calling the built executable, as is expected of integration tests in go

On this branch running a full suite of tests and generating a new coverage report we see:

The coverage of export_routes.go is actually 72.2%
<img width="421" height="42" alt="github.com/alphagov/router/lib/export_routes.go (72.2%)" src="https://github.com/user-attachments/assets/689bff87-9287-4911-aa36-aa7049d6ac6d" />

And the coverage report of main.go shows most of the content of the `if exportRoutes` block to be covered
<img width="1217" height="362" alt="A code listing from main.go with most code inside an if exportRoutes block highlighted green and only error message printing inside if err blocks highlighted as red" src="https://github.com/user-attachments/assets/13a79e50-81d9-4184-89e7-f299eb7849de" />

