### PR TITLE
Comment on PRs with a basic coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
     name: Test Go
     runs-on: ubuntu-latest
     permissions:
-        pull-requests: write
+      packages: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -44,6 +45,18 @@ jobs:
 
           # Post updated coverage report
           gh pr comment "${PR_NUMBER}" --body-file coverage/report/overall-coverage.md
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          name: coverage-report-main
+          path: coverage/report/
+          if-no-files-found: error
+          retention-days: 90
+          overwrite: true
+          include-hidden-files: false
+          archive: true
+
   golangci-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   test-go:
     name: Test Go
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -29,6 +31,19 @@ jobs:
       - run: make integration_tests
         timeout-minutes: 15
       - run: make coverage_report
+      - name: Post PR Comment with Coverage
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+
+          # Clear any previous comment
+          gh pr comment "${PR_NUMBER}" --delete-last --yes || true
+
+          # Post updated coverage report
+          gh pr comment "${PR_NUMBER}" --body-file coverage/report/overall-coverage.md
   golangci-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@
 /site_tests/node_modules
 /site_tests/test-results
 __build
-coverage/
+coverage/integration
+coverage/unit
+coverage/version
+coverage/report
+coverage/merged

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ update_deps:
 
 coverage_report:
 	go tool covdata merge -i coverage/unit,coverage/integration/,coverage/version -o coverage/merged/
-	go tool covdata percent -i coverage/merged/
 	go tool covdata textfmt -i coverage/merged/ -o coverage/report/textfmt.txt
 	go tool cover -html coverage/report/textfmt.txt -o coverage/report/coverage.html
+	go tool cover -func=coverage/report/textfmt.txt | tail -n 1 > coverage/report/overall-coverage.txt
+	./coverage/generate-markdown-summary.sh

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,7 @@ coverage_report:
 	go tool cover -html coverage/report/textfmt.txt -o coverage/report/coverage.html
 	go tool cover -func=coverage/report/textfmt.txt | tail -n 1 > coverage/report/overall-coverage.txt
 	./coverage/generate-markdown-summary.sh
+	@printf "\n\nOverall Coverage: "
+	@awk '{ print $$3; }' coverage/report/overall-coverage.txt
+	@echo
+	@go tool covdata percent -i coverage/merged | column -t

--- a/README.md
+++ b/README.md
@@ -199,6 +199,29 @@ This can be used to continue serving routes when Content Store's database is dow
 
 For details on how to configure Router to load from a file see [docs/how-to-serve-routes-from-flat-file.md](docs/how-to-serve-routes-from-flat-file.md).
 
+## Probe endpoints
+
+Several probe endpoints are provided which allow you to test the functionality of router externally.
+
+If no other routes are loaded, then none of the probe endpoint routes will be loaded and every request will return an HTTP 503 Service Unavailable..
+
+When run with the [router-probe-backend](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/router-probe-backend) backend service the available probes are:
+
+Route                              | Provided by          | HTTP Response Expected
+-----------------------------------|----------------------|------------
+`/__probe__/gone`                  | router               | Returns 410 Gone status from internally within router
+`/__probe__/router-redirect`       | router               | Returns 301 Moved Permenantly to `/__probe__/redirected`
+`/__probe__/ok`                    | router-probe-backend | Returns 200 OK
+`/__probe__/redirect`              | router-probe-backend | Returns 301 Moved Permenantly to `/__probe__/redirected`
+`/__probe__/redirected`            | router-probe-backend | Returns 200 Ok
+`/__probe__/not-found`             | router-probe-backend | Returns 404 Not Found
+`/__probe__/internal-server-error` | router-probe-backend | Returns 500 Internal Server Error
+`/__probe__/get`                   | router-probe-backend | Returns 200 Ok if the HTTP method is GET, otherwise returns 403 Forbidden
+`/__probe__/post`                  | router-probe-backend | Returns 200 Ok if the HTTP method is POST, otherwise returns 403 Forbidden
+`/__probe__/headers/get`           | router-probe-backend | Returns 200 Ok if the HTTP method is GET, with a JSON body which includes the key `requestHeaders` which is an Object of headers on the HTTP Request (with some values redacted)
+`/__probe__/headers/post`          | router-probe-backend | Returns 200 Ok if the HTTP method is POST, with a JSON body which includes the key `requestHeaders` which is an Object of headers on the HTTP Request (with some values redacted)
+`/__probe__/__canary__`            | router-probe-backend | Returns 200 Ok with a JSON body of `{"message": "Tweet tweet"}\n'}`
+
 ## Technical documentation
 
 Recommended reading: [How to Write Go Code](https://golang.org/doc/code.html)
@@ -284,6 +307,42 @@ This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) to ven
      Only `go get` and `go mod` should touch files in `vendor/`.
 
 1. Raise a PR.
+
+### View the test coverage report
+
+A coverage report is generated which includes both unit and integration test coverage merged into a single report.
+
+Runing the make target `coverage_report` will generate a coverage report which covers everything if you have already run `unit_tests` and `integration_tests` (this doesn't happen automatically for the sake of GitHub actions CI checks):
+
+```
+make unit_tests
+make integration_tests
+make coverage_report
+```
+
+The end of the coverage_report output will be a high level package statement coverage percentage, as well as an overall coverage percentage:
+
+```
+$ make coverage_report
+go tool covdata merge -i coverage/unit,coverage/integration/,coverage/version -o coverage/merged/
+go tool covdata textfmt -i coverage/merged/ -o coverage/report/textfmt.txt
+go tool cover -html coverage/report/textfmt.txt -o coverage/report/coverage.html
+go tool cover -func=coverage/report/textfmt.txt | tail -n 1 > coverage/report/overall-coverage.txt
+./coverage/generate-markdown-summary.sh
+
+
+Overall Coverage: 84.8%
+
+github.com/alphagov/router           coverage:  82.3%   of  statements
+github.com/alphagov/router/handlers  coverage:  95.6%   of  statements
+github.com/alphagov/router/lib       coverage:  80.8%   of  statements
+github.com/alphagov/router/trie      coverage:  97.7%   of  statements
+github.com/alphagov/router/triemux   coverage:  100.0%  of  statements
+````
+
+There is also a detailed textfmt report output into `coverage/report/textfmt.txt` which can be used by various other tooling.
+
+Finally there's an HTML version of the report which allows you to see individaul lines coverage broken down by file, this is output `coverage/report/coverage.html`
 
 ### Further documentation
 

--- a/coverage/generate-markdown-summary.sh
+++ b/coverage/generate-markdown-summary.sh
@@ -5,31 +5,36 @@ set -euo pipefail
 RAW_REPORT=$(mktemp)
 COVERAGE_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-go tool covdata percent -i "${COVERAGE_DIR}/merged" > "$RAW_REPORT"
-
-MARKDOWN_REPORT="${COVERAGE_DIR}/report/overall-coverage.md"
-cat > "$MARKDOWN_REPORT" <<EOF
-## Coverage report
-
-Module | Statements Covered | Happy?
--------|:------------------:|:------:
-EOF
-
 function emoji_for_percent {
   local PERCENT=$1
 
   INT_VALUE=$(printf "%.0f" "$PERCENT")
 
-  if [ "$INT_VALUE" -ge 90 ]; then
-    echo ":heart_eyes:"
+  if [ "$INT_VALUE" -ge 95 ]; then
+    echo ":star:"
+  elif [ "$INT_VALUE" -ge 90 ]; then
+    echo ":white_tick:"
   elif [ "$INT_VALUE" -ge 80 ]; then
-    echo ":smile:"
-  elif [ "$INT_VALUE" -ge 70 ]; then
-    echo ":sweat:"
+    echo ":red_circle:"
   else
-    echo ":fearful:"
+    echo ":broken_heart:"
   fi
 }
+
+go tool covdata percent -i "${COVERAGE_DIR}/merged" > "$RAW_REPORT"
+
+MARKDOWN_REPORT="${COVERAGE_DIR}/report/overall-coverage.md"
+OVERALL_COVERAGE=$(awk '{ print substr($3, 1, length($3)-1); }' "${COVERAGE_DIR}/report/overall-coverage.txt")
+OVERALL_EMOJI=$(emoji_for_percent "$OVERALL_COVERAGE")
+
+cat > "$MARKDOWN_REPORT" <<EOF
+## Coverage report
+
+Overall coverage: ${OVERALL_COVERAGE}% ${OVERALL_EMOJI}
+
+Package | Statements Covered | Happy?
+-------|:------------------:|:------:
+EOF
 
 while read -r LINE; do
   PACKAGE=$(awk '{ print $1; '} <<<"$LINE")
@@ -38,8 +43,3 @@ while read -r LINE; do
 
   echo "${PACKAGE} | ${PERCENTAGE}% | $EMOJI" >> "$MARKDOWN_REPORT"
 done < "$RAW_REPORT"
-
-OVERALL_COVERAGE=$(awk '{ print substr($3, 1, length($3)-1); }' <"${COVERAGE_DIR}/report/overall-coverage.txt")
-OVERALL_EMOJI=$(emoji_for_percent "$OVERALL_COVERAGE")
-
-echo -e "\n\nOverall coverage: ${OVERALL_COVERAGE}% ${OVERALL_EMOJI}\n" >> "$MARKDOWN_REPORT"

--- a/coverage/generate-markdown-summary.sh
+++ b/coverage/generate-markdown-summary.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RAW_REPORT=$(mktemp)
+COVERAGE_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+go tool covdata percent -i "${COVERAGE_DIR}/merged" > "$RAW_REPORT"
+
+MARKDOWN_REPORT="${COVERAGE_DIR}/report/overall-coverage.md"
+cat > "$MARKDOWN_REPORT" <<EOF
+## Coverage report
+
+Module | Statements Covered | Happy?
+-------|:------------------:|:------:
+EOF
+
+function emoji_for_percent {
+  local PERCENT=$1
+
+  INT_VALUE=$(printf "%.0f" "$PERCENT")
+
+  if [ "$INT_VALUE" -ge 90 ]; then
+    echo ":heart_eyes:"
+  elif [ "$INT_VALUE" -ge 80 ]; then
+    echo ":smile:"
+  elif [ "$INT_VALUE" -ge 70 ]; then
+    echo ":sweat:"
+  else
+    echo ":fearful:"
+  fi
+}
+
+while read -r LINE; do
+  PACKAGE=$(awk '{ print $1; '} <<<"$LINE")
+  PERCENTAGE=$(awk '{ print substr($3, 1, length($3)-1); }' <<< "$LINE")
+  EMOJI=$(emoji_for_percent "$PERCENTAGE")
+
+  echo "${PACKAGE} | ${PERCENTAGE}% | $EMOJI" >> "$MARKDOWN_REPORT"
+done < "$RAW_REPORT"
+
+OVERALL_COVERAGE=$(awk '{ print substr($3, 1, length($3)-1); }' <"${COVERAGE_DIR}/report/overall-coverage.txt")
+OVERALL_EMOJI=$(emoji_for_percent "$OVERALL_COVERAGE")
+
+echo -e "\n\nOverall coverage: ${OVERALL_COVERAGE}% ${OVERALL_EMOJI}\n" >> "$MARKDOWN_REPORT"


### PR DESCRIPTION
* Add a script to generate a github suitable markdown summary of current coverage
* Update CI workflow to post the coverage as a comment on the PR (clearing any previous ones if they have already been posted, it's annoying to end up with loads of comments if you do lots of pushes, and means the last one is the most (and only) relevant one)
* Updated make coverage_report target so it does the work and also prints a nice human readable plain text version (so it's visible easily when running locally, and visible in the github actions output)
* Updated the README with info about the coverage reports, and also documentation about the probe endpoints

I have _not_ added "coverage change from main" yet, but I plan to, baby steps :) 
You will be able to see a comment on this PR from the github-actions Bot showing the result of the new coverage commenting

In order to test the upload on main, and also so I can carry on development of coverage info I opened https://github.com/alphagov/router/pull/684 which is the same as this PR but with the artifact upload enabled for all runs. This shows the upload works fine.