### PR TITLE
Manage github actions with renovate so it can keep golangci-lint version up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,4 @@ updates:
     interval: daily
   cooldown:
     default-days: 10
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 10
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11
   codeql-sast:
     name: CodeQL SAST scan
     uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,9 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+      "config:recommended",
+      "helpers:pinGitHubActionDigests"
+  ],
   "enabledManagers": ["github-actions"],
   "minimumReleaseAge": "10 days"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "enabledManagers": ["github-actions"],
+  "minimumReleaseAge": "10 days"
+}


### PR DESCRIPTION
Currently we are not version controlling golangci-lint, which means at any time (such as last week with golangci-lint version 2.12) our tests start failing on main.

The golangci-lint github action [suggests using renovate](https://github.com/golangci/golangci-lint-action#using-renovate-to-update-the-golangci-lint-version) which will keep the action, and the version of golangci-lint up to date.

So this PR moves the management of github actions updates from dependabot to renovate, and adds a version pin for the version of golangci-lint to the previous version 2.11.4. This means renovate (when configured to manage this repo via [this other PR](https://github.com/alphagov/govuk-helm-charts/pull/4266)) will open a PR to bump golangci-lint and we can use that PR to fix the lint errors.

It also means future updates after that will be managed without having main broken, and we will have the same cooldown as other repos.