### PR TITLE
Use reusable workflow in govuk-infra for go tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test-go:
     name: Test Go
-    uses: alphagov/govuk-infrastructure/.github/workflows/go-test.yml@add-reusable-opinionated-go-test-workflow
+    uses: alphagov/govuk-infrastructure/.github/workflows/go-test.yml@main
     permissions:
       packages: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,56 +17,10 @@ concurrency:
 jobs:
   test-go:
     name: Test Go
-    runs-on: ubuntu-latest
+    uses: alphagov/govuk-infrastructure/.github/workflows/go-test.yml@add-reusable-opinionated-go-test-workflow
     permissions:
       packages: write
       pull-requests: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          show-progress: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - run: make unit_tests
-      - run: make integration_tests
-        timeout-minutes: 15
-      - name: Download coverage report from main
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          # Download coverage report (they expire after 90 days, so don't fail if there isn't one)
-          if ! gh run download --name coverage-report-main --dir coverage/report-main/; then
-            echo "Failed to download coverage report artifact 'coverage-report-main', continuing anyway"
-          fi
-      - run: make coverage_report
-      - name: Post PR Comment with Coverage
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          set -euo pipefail
-
-          # Clear any previous comment
-          gh pr comment "${PR_NUMBER}" --delete-last --yes || true
-
-          # Post updated coverage report
-          gh pr comment "${PR_NUMBER}" --body-file coverage/report/overall-coverage.md
-      - name: Upload coverage report artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          name: coverage-report-main
-          path: coverage/report/
-          if-no-files-found: error
-          retention-days: 90
-          overwrite: true
-          include-hidden-files: false
-          archive: true
 
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use the reusable workflow from https://github.com/alphagov/govuk-infrastructure/pull/4184 to run the go tests in this repo