### PR TITLE
Remove stringPtr function and replace usage with new()

### DIFF
--- a/lib/load_routes_test.go
+++ b/lib/load_routes_test.go
@@ -65,8 +65,8 @@ var _ = Describe("loadRoutes", func() {
 	Context("when content store has backend routes", func() {
 		BeforeEach(func() {
 			rows := pgxmock.NewRows([]string{"backend", "path", "match_type", "destination", "segments_mode", "schema_name", "details"}).
-				AddRow(stringPtr("backend1"), stringPtr("/path1"), stringPtr("exact"), nil, nil, stringPtr("guidance"), stringPtr("")).
-				AddRow(stringPtr("backend2"), stringPtr("/path2"), stringPtr("prefix"), nil, nil, stringPtr("guidance"), stringPtr(""))
+				AddRow(new("backend1"), new("/path1"), new("exact"), nil, nil, new("guidance"), new("")).
+				AddRow(new("backend2"), new("/path2"), new("prefix"), nil, nil, new("guidance"), new(""))
 
 			mockPool.ExpectQuery("WITH").WillReturnRows(rows)
 
@@ -122,12 +122,12 @@ var _ = Describe("loadRoutes", func() {
 	Context("when content store has gone routes", func() {
 		BeforeEach(func() {
 			rows := pgxmock.NewRows([]string{"backend", "path", "match_type", "destination", "segments_mode", "schema_name", "details"}).
-				AddRow(nil, stringPtr("/frontend-gone"), stringPtr("exact"), nil, nil, stringPtr("gone"), stringPtr("{\"explanation\": \"this is gone\", \"alternative_path\": null}")).
-				AddRow(stringPtr("backend2"), stringPtr("/backend-gone"), stringPtr("exact"), nil, nil, stringPtr("gone"), stringPtr("{\"explanation\": \"this is gone\", \"alternative_path\": null}")).
-				AddRow(stringPtr("backend1"), stringPtr("/guidance"), stringPtr("exact"), nil, nil, stringPtr("guidance"), stringPtr("")).
-				AddRow(nil, stringPtr("/gone-empty-attributes"), stringPtr("exact"), nil, nil, stringPtr("gone"), stringPtr("{\"explanation\": null, \"alternative_path\": null}")).
-				AddRow(nil, stringPtr("/gone-empty-details"), stringPtr("exact"), nil, nil, stringPtr("gone"), stringPtr("{}")).
-				AddRow(nil, stringPtr("/gone-nil-details"), stringPtr("exact"), nil, nil, stringPtr("gone"), nil)
+				AddRow(nil, new("/frontend-gone"), new("exact"), nil, nil, new("gone"), new("{\"explanation\": \"this is gone\", \"alternative_path\": null}")).
+				AddRow(new("backend2"), new("/backend-gone"), new("exact"), nil, nil, new("gone"), new("{\"explanation\": \"this is gone\", \"alternative_path\": null}")).
+				AddRow(new("backend1"), new("/guidance"), new("exact"), nil, nil, new("guidance"), new("")).
+				AddRow(nil, new("/gone-empty-attributes"), new("exact"), nil, nil, new("gone"), new("{\"explanation\": null, \"alternative_path\": null}")).
+				AddRow(nil, new("/gone-empty-details"), new("exact"), nil, nil, new("gone"), new("{}")).
+				AddRow(nil, new("/gone-nil-details"), new("exact"), nil, nil, new("gone"), nil)
 
 			mockPool.ExpectQuery("WITH").WillReturnRows(rows)
 
@@ -181,12 +181,12 @@ var _ = Describe("loadRoutes", func() {
 	Context("when content store has redirect routes", func() {
 		BeforeEach(func() {
 			rows := pgxmock.NewRows([]string{"backend", "path", "match_type", "destination", "segments_mode", "schema_name", "details"}).
-				AddRow(nil, stringPtr("/redirect-exact"), stringPtr("exact"), stringPtr("/redirected-exact"), nil, stringPtr("redirect"), nil).
-				AddRow(nil, stringPtr("/redirect-prefix"), stringPtr("prefix"), stringPtr("/redirected-prefix"), nil, stringPtr("redirect"), nil).
-				AddRow(nil, stringPtr("/redirect-exact-ignore"), stringPtr("exact"), stringPtr("/redirected-exact-ignore"), stringPtr("ignore"), stringPtr("redirect"), nil).
-				AddRow(nil, stringPtr("/redirect-prefix-ignore"), stringPtr("prefix"), stringPtr("/redirected-prefix-ignore"), stringPtr("ignore"), stringPtr("redirect"), nil).
-				AddRow(nil, stringPtr("/redirect-exact-preserve"), stringPtr("exact"), stringPtr("/redirected-exact-preserve"), stringPtr("preserve"), stringPtr("redirect"), nil).
-				AddRow(nil, stringPtr("/redirect-prefix-preserve"), stringPtr("prefix"), stringPtr("/redirected-prefix-preserve"), stringPtr("preserve"), stringPtr("redirect"), nil)
+				AddRow(nil, new("/redirect-exact"), new("exact"), new("/redirected-exact"), nil, new("redirect"), nil).
+				AddRow(nil, new("/redirect-prefix"), new("prefix"), new("/redirected-prefix"), nil, new("redirect"), nil).
+				AddRow(nil, new("/redirect-exact-ignore"), new("exact"), new("/redirected-exact-ignore"), new("ignore"), new("redirect"), nil).
+				AddRow(nil, new("/redirect-prefix-ignore"), new("prefix"), new("/redirected-prefix-ignore"), new("ignore"), new("redirect"), nil).
+				AddRow(nil, new("/redirect-exact-preserve"), new("exact"), new("/redirected-exact-preserve"), new("preserve"), new("redirect"), nil).
+				AddRow(nil, new("/redirect-prefix-preserve"), new("prefix"), new("/redirected-prefix-preserve"), new("preserve"), new("redirect"), nil)
 			mockPool.ExpectQuery("WITH").WillReturnRows(rows)
 
 			err := loadRoutes(mockPool, mux, backends, logger)
@@ -350,8 +350,8 @@ var _ = Describe("Router", func() {
 
 		It("should reload routes from content store successfully", func() {
 			rows := pgxmock.NewRows([]string{"backend", "path", "match_type", "destination", "segments_mode", "schema_name", "details"}).
-				AddRow(stringPtr("backend1"), stringPtr("/path1"), stringPtr("exact"), nil, nil, stringPtr("guidance"), stringPtr("")).
-				AddRow(stringPtr("backend2"), stringPtr("/path2"), stringPtr("prefix"), nil, nil, stringPtr("guidance"), stringPtr(""))
+				AddRow(new("backend1"), new("/path1"), new("exact"), nil, nil, new("guidance"), new("")).
+				AddRow(new("backend2"), new("/path2"), new("prefix"), nil, nil, new("guidance"), new(""))
 
 			mockPool.ExpectQuery("WITH").WillReturnRows(rows)
 

--- a/lib/routes_test.go
+++ b/lib/routes_test.go
@@ -16,15 +16,15 @@ var _ = Describe("Route", func() {
 		Context("when schema is 'gone', but content items has details", func() {
 			It("should return a backend", func() {
 				backendID := "some-backend"
-				route.SchemaName = stringPtr("gone")
+				route.SchemaName = new("gone")
 				route.BackendID = &backendID
-				route.Details = stringPtr(`{"key": "value"}`)
+				route.Details = new(`{"key": "value"}`)
 				Expect(route.backend()).To(Equal(&backendID))
 			})
 
 			It("should return 'frontend' if backend is nil", func() {
-				route.SchemaName = stringPtr("gone")
-				route.Details = stringPtr(`{"key": "value"}`)
+				route.SchemaName = new("gone")
+				route.Details = new(`{"key": "value"}`)
 				Expect(*route.backend()).To(Equal("frontend"))
 			})
 		})
@@ -41,14 +41,14 @@ var _ = Describe("Route", func() {
 	Describe("handlerType", func() {
 		Context("when route is a redirect", func() {
 			It("should return 'redirect'", func() {
-				route.SchemaName = stringPtr("redirect")
+				route.SchemaName = new("redirect")
 				Expect(route.handlerType()).To(Equal(HandlerTypeRedirect))
 			})
 		})
 
 		Context("when route is gone", func() {
 			It("should return 'gone'", func() {
-				route.SchemaName = stringPtr("gone")
+				route.SchemaName = new("gone")
 				Expect(route.handlerType()).To(Equal(HandlerTypeGone))
 			})
 		})
@@ -63,14 +63,14 @@ var _ = Describe("Route", func() {
 	Describe("gone", func() {
 		Context("when schema is 'gone' and details is nil", func() {
 			It("should return true", func() {
-				route.SchemaName = stringPtr("gone")
+				route.SchemaName = new("gone")
 				Expect(route.gone()).To(BeTrue())
 			})
 		})
 
 		Context("when schema is 'gone' and details is empty", func() {
 			It("should return true", func() {
-				route.SchemaName = stringPtr("gone")
+				route.SchemaName = new("gone")
 				details := "{}"
 				route.Details = &details
 				Expect(route.gone()).To(BeTrue())
@@ -79,7 +79,7 @@ var _ = Describe("Route", func() {
 
 		Context("when schema is 'gone' and details is not empty", func() {
 			It("should return false", func() {
-				route.SchemaName = stringPtr("gone")
+				route.SchemaName = new("gone")
 				details := `{"key1": "value", "key2": null}`
 				route.Details = &details
 				Expect(route.gone()).To(BeFalse())
@@ -88,7 +88,7 @@ var _ = Describe("Route", func() {
 
 		Context("when schema is 'gone' and details is invalid json", func() {
 			It("should return true", func() {
-				route.SchemaName = stringPtr("gone")
+				route.SchemaName = new("gone")
 				details := "{invalid}"
 				route.Details = &details
 				Expect(route.gone()).To(BeTrue())
@@ -105,14 +105,14 @@ var _ = Describe("Route", func() {
 	Describe("redirect", func() {
 		Context("when schema is 'redirect'", func() {
 			It("should return true", func() {
-				route.SchemaName = stringPtr("redirect")
+				route.SchemaName = new("redirect")
 				Expect(route.redirect()).To(BeTrue())
 			})
 		})
 
 		Context("when schema is not 'redirect'", func() {
 			It("should return false", func() {
-				route.SchemaName = stringPtr("guidance")
+				route.SchemaName = new("guidance")
 				Expect(route.redirect()).To(BeFalse())
 			})
 		})
@@ -121,36 +121,32 @@ var _ = Describe("Route", func() {
 	Describe("segmentsMode", func() {
 		Context("when segments mode is nil and schema is 'redirect'", func() {
 			It("should return 'preserve' if route type is 'prefix'", func() {
-				route.SchemaName = stringPtr("redirect")
-				route.RouteType = stringPtr("prefix")
+				route.SchemaName = new("redirect")
+				route.RouteType = new("prefix")
 				Expect(route.segmentsMode()).To(Equal("preserve"))
 			})
 
 			It("should return 'ignore' if route type is not 'prefix'", func() {
-				route.SchemaName = stringPtr("redirect")
-				route.RouteType = stringPtr("other")
+				route.SchemaName = new("redirect")
+				route.RouteType = new("other")
 				Expect(route.segmentsMode()).To(Equal("ignore"))
 			})
 		})
 
 		Context("when segments mode is set and schema is redirect", func() {
 			It("should return set segments mode regardless if prefix", func() {
-				route.SchemaName = stringPtr("redirect")
-				route.RouteType = stringPtr("prefix")
-				route.SegmentsMode = stringPtr("ignore")
+				route.SchemaName = new("redirect")
+				route.RouteType = new("prefix")
+				route.SegmentsMode = new("ignore")
 				Expect(route.segmentsMode()).To(Equal("ignore"))
 			})
 
 			It("should return set segments mode regardless if not prefix", func() {
-				route.SchemaName = stringPtr("redirect")
-				route.RouteType = stringPtr("exact")
-				route.SegmentsMode = stringPtr("preserve")
+				route.SchemaName = new("redirect")
+				route.RouteType = new("exact")
+				route.SegmentsMode = new("preserve")
 				Expect(route.segmentsMode()).To(Equal("preserve"))
 			})
 		})
 	})
 })
-
-func stringPtr(s string) *string {
-	return &s
-}


### PR DESCRIPTION
Golang 1.26 added the ability to provide an [arbitrary expression to the `new` builtin](https://go.dev/doc/go1.26#language): `new(<expr>)`.

The expression is evaluated, the result stored in memory, and a pointer to the memory address returned. This was a big change from previously where new only created uninitialised variables.

We no longer need a stringPtr function and can just use `new(<string>)` instead. So this PR removes the stringPtr function and replaces its usage with `new(<string>)`.

See [this excellent medium article by ElAmir Mansour](https://elamir.medium.com/golang-1-26-update-stop-writing-pointer-helpers-with-new-expr-7d8296e15fb8) for deeper information about this change, and why it's good :)