### PR TITLE
Extend govuk-infra renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
       "config:recommended",
-      "helpers:pinGitHubActionDigests"
+      "helpers:pinGitHubActionDigests",
+      "github>alphagov/govuk-infrastructure:renovate"
   ],
   "enabledManagers": ["github-actions"],
   "minimumReleaseAge": "10 days"


### PR DESCRIPTION
Extend the renovate config in govuk-infrastructure to avoid PRs like https://github.com/alphagov/router/pull/689